### PR TITLE
Ensure deepseek API handler returns after success

### DIFF
--- a/pages/api/deepseek.js
+++ b/pages/api/deepseek.js
@@ -58,7 +58,7 @@ export default async function handler(req, res) {
 
     const data = await main()
 
-    res?.status(200).json({ success: true, data })
+    return res?.status(200).json({ success: true, data })
   }
 
   return res?.status(400).json({ success: false, error: 'Wrong method' })


### PR DESCRIPTION
## Summary
- ensure the deepseek API handler returns immediately after sending a successful response
- keep the 400 error branch limited to unsupported HTTP methods

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b937d50c8329b545c02f556a979b