### PR TITLE
Improve referral sharing UX

### DIFF
--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -27,6 +27,7 @@ import { faUpload } from '@fortawesome/free-solid-svg-icons/faUpload'
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers'
 import { faUserTie } from '@fortawesome/free-solid-svg-icons/faUserTie'
 import { faUserTimes } from '@fortawesome/free-solid-svg-icons/faUserTimes'
+import { faUserPlus } from '@fortawesome/free-solid-svg-icons/faUserPlus'
 import { faVenus } from '@fortawesome/free-solid-svg-icons/faVenus'
 import { faBug } from '@fortawesome/free-solid-svg-icons/faBug'
 import { faCog } from '@fortawesome/free-solid-svg-icons/faCog'
@@ -177,6 +178,7 @@ import badgeBirthdaysTodayCountSelector from '@state/selectors/badgeBirthdaysTod
 import { uid } from 'uid'
 import ImagesServerContent from '@layouts/content/ImagesServerContent'
 import LikesContent from '@layouts/content/LikesContent'
+import ReferralsContent from '@layouts/content/ReferralsContent'
 import badgeLoggedUserLikesToSeeSelector from '@state/selectors/badgeLoggedUserLikesToSeeSelector'
 import RemindDatesContent from '@layouts/content/RemindDatesContent'
 import WhatsappMessagesContent from '@layouts/content/WhatsappMessagesContent'
@@ -2052,6 +2054,12 @@ export const CONTENTS = Object.freeze({
     accessStatuses: ['member'],
     roleAccess: (role, status) => role?.seeMyStatistics || status === 'member',
   },
+  referrals: {
+    Component: ReferralsContent,
+    name: 'Реферальная программа',
+    accessRoles: ['client', 'moder', 'admin', 'supervisor', 'dev'],
+    roleAccess: () => true,
+  },
   imagesServer: {
     Component: ImagesServerContent,
     name: 'Сервер картинок',
@@ -2081,6 +2089,14 @@ export const pages = [
     icon: faTrophy,
     // accessRoles: CONTENTS['userStatistics'].accessRoles,
     roleAccess: CONTENTS['userStatistics'].roleAccess,
+  },
+  {
+    id: 1,
+    group: 0,
+    name: 'Рефералы',
+    href: 'referrals',
+    icon: faUserPlus,
+    roleAccess: CONTENTS['referrals'].roleAccess,
   },
   {
     id: 2,

--- a/layouts/content/ReferralsContent.js
+++ b/layouts/content/ReferralsContent.js
@@ -1,0 +1,194 @@
+'use client'
+
+import Button from '@components/Button'
+import LoadingSpinner from '@components/LoadingSpinner'
+import Note from '@components/Note'
+import UserName from '@components/UserName'
+import formatDate from '@helpers/formatDate'
+import useSnackbar from '@helpers/useSnackbar'
+import loggedUserActiveAtom from '@state/atoms/loggedUserActiveAtom'
+import locationAtom from '@state/atoms/locationAtom'
+import modalsFuncAtom from '@state/modalsFuncAtom'
+import usersAtomAsync from '@state/async/usersAtomAsync'
+import { useAtomValue } from 'jotai'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/router'
+
+const ReferralsContent = () => {
+  const loggedUser = useAtomValue(loggedUserActiveAtom)
+  const location = useAtomValue(locationAtom)
+  const users = useAtomValue(usersAtomAsync)
+  const modalsFunc = useAtomValue(modalsFuncAtom)
+  const router = useRouter()
+  const { success, error } = useSnackbar()
+
+  const [origin, setOrigin] = useState('')
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setOrigin(window.location.origin)
+    }
+  }, [])
+
+  const referralPath = useMemo(() => {
+    if (!loggedUser?._id || !location) return ''
+    return `/${location}/login?registration=true&ref=${loggedUser._id}`
+  }, [loggedUser?._id, location])
+
+  const referralLink = useMemo(() => {
+    if (!referralPath) return ''
+    return origin ? `${origin}${referralPath}` : referralPath
+  }, [origin, referralPath])
+
+  const referrals = useMemo(() => {
+    if (!Array.isArray(users) || !loggedUser?._id) return []
+    return users.filter(
+      (user) =>
+        user?.referrerId && String(user.referrerId) === String(loggedUser._id)
+    )
+  }, [users, loggedUser?._id])
+
+  const sortedReferrals = useMemo(() => {
+    return [...referrals].sort((a, b) => {
+      const dateA = a?.createdAt ? new Date(a.createdAt).getTime() : 0
+      const dateB = b?.createdAt ? new Date(b.createdAt).getTime() : 0
+      return dateB - dateA
+    })
+  }, [referrals])
+
+  const handleCopy = useCallback(async () => {
+    if (!referralLink) return
+
+    try {
+      await navigator.clipboard.writeText(referralLink)
+      success('Реферальная ссылка скопирована в буфер обмена')
+    } catch (copyError) {
+      error('Не удалось автоматически скопировать ссылку')
+    }
+  }, [referralLink, success, error])
+
+  const handleQrCode = useCallback(() => {
+    if (!referralLink || !modalsFunc?.external?.qrCodeGenerator) return
+
+    modalsFunc.external.qrCodeGenerator({
+      title: 'QR-код реферальной ссылки',
+      link: referralLink,
+    })
+  }, [modalsFunc, referralLink])
+
+  const handleOpenReferral = useCallback(
+    (userId) => {
+      if (!location || !userId) return
+      router.push(`/${location}/user/${userId}`)
+    },
+    [router, location]
+  )
+
+  if (!loggedUser?._id) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <LoadingSpinner text="Загрузка профиля..." />
+      </div>
+    )
+  }
+
+  if (!Array.isArray(users)) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <LoadingSpinner text="Загрузка списка пользователей..." />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4 px-1 pb-4">
+      <div className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+        <div className="text-lg font-semibold text-general">
+          Ваша реферальная ссылка
+        </div>
+        <div className="mt-2 text-sm break-all text-gray-700">
+          {referralLink || 'Ссылка появится после загрузки данных пользователя'}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 mt-3">
+          <Button
+            name="Скопировать ссылку"
+            onClick={handleCopy}
+            disabled={!referralLink}
+          />
+          <Button
+            name="QR код"
+            outline
+            classOutlineColor="border-general"
+            classOutlineTextColor="text-general"
+            classHoverOutlineColor="hover:border-general"
+            classHoverOutlineTextColor="hover:text-general"
+            onClick={handleQrCode}
+            disabled={!referralLink}
+          />
+        </div>
+        <Note className="mt-3">
+          Поделитесь этой ссылкой с друзьями. После регистрации по ней вы
+          увидите их в списке своих рефералов.
+        </Note>
+      </div>
+
+      <div className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+        <div className="flex items-center justify-between">
+          <div className="text-lg font-semibold text-general">
+            Мои рефералы
+          </div>
+          <div className="text-sm text-gray-600">
+            {sortedReferrals.length}{' '}
+            {sortedReferrals.length === 1
+              ? 'приглашенный пользователь'
+              : 'приглашенных пользователей'}
+          </div>
+        </div>
+        {sortedReferrals.length === 0 ? (
+          <div className="mt-4 text-gray-600">
+            Пока нет пользователей, зарегистрировавшихся по вашей ссылке.
+          </div>
+        ) : (
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full text-left border border-gray-200 divide-y divide-gray-200 rounded-lg">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-sm font-medium text-gray-600">
+                    Имя
+                  </th>
+                  <th className="px-4 py-2 text-sm font-medium text-gray-600">
+                    Телефон
+                  </th>
+                  <th className="px-4 py-2 text-sm font-medium text-gray-600">
+                    Дата регистрации
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {sortedReferrals.map((user) => (
+                  <tr
+                    key={user._id}
+                    className="transition-colors cursor-pointer hover:bg-gray-50"
+                    onClick={() => handleOpenReferral(user._id)}
+                  >
+                    <td className="px-4 py-2 text-sm text-gray-700">
+                      <UserName user={user} />
+                    </td>
+                    <td className="px-4 py-2 text-sm text-gray-700">
+                      {user.phone ? `+${user.phone}` : '—'}
+                    </td>
+                    <td className="px-4 py-2 text-sm text-gray-700">
+                      {user.createdAt ? formatDate(user.createdAt) : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default ReferralsContent

--- a/layouts/modals/modalsFunc/qrCodeGeneratorFunc.js
+++ b/layouts/modals/modalsFunc/qrCodeGeneratorFunc.js
@@ -3,7 +3,7 @@ import { useAtomValue } from 'jotai'
 import locationAtom from '@state/atoms/locationAtom'
 import { useRouter } from 'next/router'
 
-const qrCodeGeneratorFunc = ({ type, id, title }) => {
+const qrCodeGeneratorFunc = ({ type, id, title, link }) => {
   const QRCodeGeneratorFuncModal = ({
     closeModal,
     setOnConfirmFunc,
@@ -19,12 +19,19 @@ const qrCodeGeneratorFunc = ({ type, id, title }) => {
         ? window.location.origin
         : ''
 
+    const targetLink = link
+      ? link
+      : `${origin ? `${origin}/` : '/'}${location}/cabinet/${
+          type ?? router.query.page
+        }${id ? `?id=${id}` : ''}`
+    const encodedLink = encodeURIComponent(targetLink)
+
     return (
       <FormWrapper flex className="flex justify-center">
         {/* <div className="relative"> */}
         <img
           className="max-w-[300px] aspect-1 w-full"
-          src={`https://api.qrserver.com/v1/create-qr-code/?data=${origin}/${location}/cabinet/${type ?? router.query.page}${id ? `?id=${id}` : ''}&amp;size=300x300`}
+          src={`https://api.qrserver.com/v1/create-qr-code/?data=${encodedLink}&size=300x300`}
           alt="qr-code"
         />
         {/* <Image

--- a/pages/[location]/login.js
+++ b/pages/[location]/login.js
@@ -364,6 +364,12 @@ const LoginPage = (props) => {
 
   const { location } = props
 
+  const referralId = useMemo(() => {
+    const value = router.query?.ref ?? router.query?.referrer
+    if (Array.isArray(value)) return value[0]
+    return typeof value === 'string' ? value : undefined
+  }, [router.query])
+
   const [process, setProcess] = useState('authorization')
   const [type, setType] = useState()
   const [registrationLevel, setRegistrationLevel] = useState(1)
@@ -428,6 +434,7 @@ const LoginPage = (props) => {
           username: username === 'undefined' ? undefined : username,
           registration: forceReg || isRegistration ? 'true' : 'false',
           location,
+          referrerId: referralId,
         }).then((res) => {
           if (res?.error === 'CredentialsSignin') {
             setWaitingResponse(false)
@@ -461,6 +468,7 @@ const LoginPage = (props) => {
       setTelegramRegistrationConfirm,
       setWaitingResponse,
       setInputPassword,
+      referralId,
     ]
   )
 
@@ -800,6 +808,7 @@ const LoginPage = (props) => {
             forgotPassword: isForgotPassword,
             soctag,
             custag,
+            referrerId: referralId,
           },
           (res) => {
             if (res.error) {

--- a/schemas/usersSchema.js
+++ b/schemas/usersSchema.js
@@ -127,6 +127,11 @@ const usersSchema = {
     type: String,
     default: 'novice',
   },
+  referrerId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Users',
+    default: null,
+  },
   lastActivityAt: {
     type: Date,
     default: () => Date.now(),

--- a/state/modalsFuncAtom.js
+++ b/state/modalsFuncAtom.js
@@ -854,12 +854,13 @@ const modalsFuncGenerator = (get, set) => {
         )
       ),
     external: {
-      qrCodeGenerator: ({ type, id, title }) =>
+      qrCodeGenerator: ({ type, id, title, link }) =>
         addModal(
           require('../layouts/modals/modalsFunc/qrCodeGeneratorFunc').default({
             type,
             id,
             title,
+            link,
           })
         ),
       ai: () =>


### PR DESCRIPTION
## Summary
- direct referral links to the registration flow and surface copy feedback via toast notifications
- show referral names via the privacy-aware component, make entries open the questionnaire, and add a QR-code button for sharing
- allow the QR-code modal to render arbitrary links, including referral URLs, and ensure the referral shortcut passes its link into the modal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6bf8610e88329bbcffef353f4ec6f