### PR TITLE
Add center and club toggles to referral program

### DIFF
--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -10,7 +10,9 @@ import { faEnvelope } from '@fortawesome/free-solid-svg-icons/faEnvelope'
 import { faGenderless } from '@fortawesome/free-solid-svg-icons/faGenderless'
 import { faHands } from '@fortawesome/free-solid-svg-icons/faHands'
 import { faHandshake } from '@fortawesome/free-solid-svg-icons/faHandshake'
+import { faHandsHoldingHeart } from '@fortawesome/free-solid-svg-icons/faHandsHoldingHeart'
 import { faHistory } from '@fortawesome/free-solid-svg-icons/faHistory'
+import { faGift } from '@fortawesome/free-solid-svg-icons/faGift'
 import { faLock } from '@fortawesome/free-solid-svg-icons/faLock'
 import { faMars } from '@fortawesome/free-solid-svg-icons/faMars'
 import { faMedal } from '@fortawesome/free-solid-svg-icons/faMedal'
@@ -137,6 +139,9 @@ const LoggedUserNotificationsContent = dynamic(
 const SettingsFabMenuContent = dynamic(
   () => import('@layouts/content/SettingsFabMenuContent')
 )
+const SettingsReferralSystemContent = dynamic(
+  () => import('@layouts/content/SettingsReferralSystemContent')
+)
 const SettingsRolesContent = dynamic(
   () => import('@layouts/content/SettingsRolesContent')
 )
@@ -177,6 +182,7 @@ import badgeBirthdaysTodayCountSelector from '@state/selectors/badgeBirthdaysTod
 import { uid } from 'uid'
 import ImagesServerContent from '@layouts/content/ImagesServerContent'
 import LikesContent from '@layouts/content/LikesContent'
+import ReferralsContent from '@layouts/content/ReferralsContent'
 import badgeLoggedUserLikesToSeeSelector from '@state/selectors/badgeLoggedUserLikesToSeeSelector'
 import RemindDatesContent from '@layouts/content/RemindDatesContent'
 import WhatsappMessagesContent from '@layouts/content/WhatsappMessagesContent'
@@ -700,6 +706,8 @@ export const DEFAULT_PAYMENT = Object.freeze({
   status: 'created',
   payAt: undefined,
   comment: '',
+  isReferralCoupon: false,
+  referralReward: null,
 })
 
 export const DEFAULT_ADDITIONAL_BLOCK = Object.freeze({
@@ -755,6 +763,14 @@ export const DEFAULT_SITE_SETTINGS = Object.freeze({
   instagram: '',
   vk: '',
   codeSendService: 'telefonip',
+  referralProgram: {
+    enabled: false,
+    enabledForCenter: false,
+    enabledForClub: false,
+    referrerCouponAmount: 0,
+    referralCouponAmount: 0,
+    requirePaidEvent: false,
+  },
 })
 
 export const EVENT_RELATIONSHIP_ACCESS = [
@@ -1037,6 +1053,7 @@ export const DEFAULT_ROLES = [
     siteSettings: {
       phoneConfirmService: false,
       fabMenu: false,
+      referralSystem: false,
       roles: false,
       dateStartProject: false,
       headerInfo: false,
@@ -1176,6 +1193,7 @@ export const DEFAULT_ROLES = [
     siteSettings: {
       phoneConfirmService: false,
       fabMenu: false,
+      referralSystem: false,
       roles: false,
       dateStartProject: false,
       headerInfo: false,
@@ -1315,6 +1333,7 @@ export const DEFAULT_ROLES = [
     siteSettings: {
       phoneConfirmService: false,
       fabMenu: false,
+      referralSystem: false,
       roles: false,
       dateStartProject: false,
       headerInfo: false,
@@ -1454,6 +1473,7 @@ export const DEFAULT_ROLES = [
     siteSettings: {
       phoneConfirmService: false,
       fabMenu: true,
+      referralSystem: true,
       roles: true,
       dateStartProject: false,
       headerInfo: true,
@@ -1593,6 +1613,7 @@ export const DEFAULT_ROLES = [
     siteSettings: {
       phoneConfirmService: false,
       fabMenu: true,
+      referralSystem: true,
       roles: true,
       dateStartProject: false,
       headerInfo: true,
@@ -1732,6 +1753,7 @@ export const DEFAULT_ROLES = [
     siteSettings: {
       phoneConfirmService: true,
       fabMenu: true,
+      referralSystem: true,
       roles: true,
       dateStartProject: true,
       headerInfo: true,
@@ -1795,6 +1817,35 @@ export const SOCIALS = [
     color: 'blue-400',
   },
 ]
+
+const getReferralProgramFlags = (referralProgram = {}) => {
+  const fallbackEnabled = referralProgram?.enabled === true
+  const enabledForCenter =
+    typeof referralProgram?.enabledForCenter === 'boolean'
+      ? referralProgram.enabledForCenter
+      : fallbackEnabled
+  const enabledForClub =
+    typeof referralProgram?.enabledForClub === 'boolean'
+      ? referralProgram.enabledForClub
+      : fallbackEnabled
+
+  return {
+    enabledForCenter,
+    enabledForClub,
+    isEnabled: enabledForCenter || enabledForClub,
+  }
+}
+
+const isReferralProgramEnabled = (referralProgram) =>
+  getReferralProgramFlags(referralProgram).isEnabled
+
+const isReferralProgramEnabledForStatus = (referralProgram, status) => {
+  const { enabledForCenter, enabledForClub } =
+    getReferralProgramFlags(referralProgram)
+
+  if (status === 'member') return enabledForClub
+  return enabledForCenter
+}
 
 export const CONTENTS = Object.freeze({
   services: {
@@ -2027,6 +2078,12 @@ export const CONTENTS = Object.freeze({
     accessRoles: ['supervisor', 'dev'],
     roleAccess: (role) => role?.siteSettings?.fabMenu,
   },
+  settingsReferralSystem: {
+    Component: SettingsReferralSystemContent,
+    name: 'Настройки / Реферальная система',
+    accessRoles: ['supervisor', 'dev'],
+    roleAccess: (role) => role?.siteSettings?.referralSystem,
+  },
   settingsDateStartProject: {
     Component: SettingsDateStartProjectContent,
     name: 'Настройки / Дата старта проекта',
@@ -2051,6 +2108,22 @@ export const CONTENTS = Object.freeze({
     accessRoles: ['client', 'admin', 'supervisor', 'dev'],
     accessStatuses: ['member'],
     roleAccess: (role, status) => role?.seeMyStatistics || status === 'member',
+  },
+  referrals: {
+    Component: ReferralsContent,
+    name: 'Реферальная программа',
+    accessRoles: ['client', 'moder', 'admin', 'supervisor', 'dev'],
+    roleAccess: (role, status, siteSettings) => {
+      const roleId = role?._id
+      if (roleId && roleId !== 'client') return true
+
+      return isReferralProgramEnabledForStatus(
+        siteSettings?.referralProgram,
+        status
+      )
+    },
+    siteConfirm: (siteSettings) =>
+      isReferralProgramEnabled(siteSettings?.referralProgram),
   },
   imagesServer: {
     Component: ImagesServerContent,
@@ -2083,6 +2156,15 @@ export const pages = [
     roleAccess: CONTENTS['userStatistics'].roleAccess,
   },
   {
+    id: 1,
+    group: 12,
+    name: 'Рефералы',
+    href: 'referrals',
+    icon: faHandshake,
+    roleAccess: CONTENTS['referrals'].roleAccess,
+    siteConfirm: CONTENTS['referrals'].siteConfirm,
+  },
+  {
     id: 2,
     group: 1,
     name: 'Лайки',
@@ -2098,7 +2180,7 @@ export const pages = [
     group: 2,
     name: 'Услуги',
     href: 'services',
-    icon: faHandshake,
+    icon: faHandsHoldingHeart,
     // accessRoles: CONTENTS['services'].accessRoles,
     roleAccess: CONTENTS['services'].roleAccess,
   },
@@ -2397,6 +2479,15 @@ export const pages = [
     roleAccess: CONTENTS['settingsFabMenu'].roleAccess,
   },
   {
+    id: 86,
+    group: 11,
+    name: 'Реферальная система',
+    href: 'settingsReferralSystem',
+    icon: faGift,
+    // accessRoles: CONTENTS['settingsReferralSystem'].accessRoles,
+    roleAccess: CONTENTS['settingsReferralSystem'].roleAccess,
+  },
+  {
     id: 82,
     group: 11,
     name: 'Роли',
@@ -2471,6 +2562,12 @@ export const pagesGroups = [
     // accessStatuses: ['member'],
   },
   {
+    id: 12,
+    name: 'Рефералы',
+    icon: faHandshake,
+    // accessRoles: ['client', 'moder', 'admin', 'supervisor', 'dev'],
+  },
+  {
     id: 3,
     name: 'Мероприятия',
     icon: faCalendarAlt,
@@ -2485,7 +2582,7 @@ export const pagesGroups = [
   {
     id: 2,
     name: 'Услуги',
-    icon: faHandshake,
+    icon: faHandsHoldingHeart,
     // accessRoles: ['client', 'admin', 'supervisor', 'dev'],
   },
   {

--- a/layouts/SideBar.js
+++ b/layouts/SideBar.js
@@ -39,7 +39,7 @@ const menuCfg = (
       const pagesItems = pages.reduce((totalPages, page) => {
         if (
           page.group === group.id &&
-          page.roleAccess(userActiveRole, userActiveStatusName) &&
+          page.roleAccess(userActiveRole, userActiveStatusName, siteSettings) &&
           (!page.siteConfirm ||
             (typeof page.siteConfirm === 'function' &&
               page.siteConfirm(siteSettings)))

--- a/layouts/content/ReferralsContent.js
+++ b/layouts/content/ReferralsContent.js
@@ -1,0 +1,314 @@
+'use client'
+
+import Button from '@components/Button'
+import LoadingSpinner from '@components/LoadingSpinner'
+import Note from '@components/Note'
+import UserName from '@components/UserName'
+import formatDate from '@helpers/formatDate'
+import useSnackbar from '@helpers/useSnackbar'
+import loggedUserActiveAtom from '@state/atoms/loggedUserActiveAtom'
+import locationAtom from '@state/atoms/locationAtom'
+import modalsFuncAtom from '@state/modalsFuncAtom'
+import usersAtomAsync from '@state/async/usersAtomAsync'
+import siteSettingsAtom from '@state/atoms/siteSettingsAtom'
+import eventsAtom from '@state/atoms/eventsAtom'
+import asyncEventsUsersAllAtom from '@state/async/asyncEventsUsersAllAtom'
+import { useAtomValue } from 'jotai'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/router'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle'
+import { faTimesCircle } from '@fortawesome/free-solid-svg-icons/faTimesCircle'
+
+const ReferralsContent = () => {
+  const loggedUser = useAtomValue(loggedUserActiveAtom)
+  const location = useAtomValue(locationAtom)
+  const users = useAtomValue(usersAtomAsync)
+  const siteSettings = useAtomValue(siteSettingsAtom)
+  const events = useAtomValue(eventsAtom)
+  const eventsUsers = useAtomValue(asyncEventsUsersAllAtom)
+  const modalsFunc = useAtomValue(modalsFuncAtom)
+  const router = useRouter()
+  const { success, error } = useSnackbar()
+
+  const [origin, setOrigin] = useState('')
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setOrigin(window.location.origin)
+    }
+  }, [])
+
+  const referralPath = useMemo(() => {
+    if (!loggedUser?._id || !location) return ''
+    return `/${location}/login?registration=true&ref=${loggedUser._id}`
+  }, [loggedUser?._id, location])
+
+  const referralLink = useMemo(() => {
+    if (!referralPath) return ''
+    return origin ? `${origin}${referralPath}` : referralPath
+  }, [origin, referralPath])
+
+  const referralProgram = siteSettings?.referralProgram ?? {}
+
+  const formatCurrency = useCallback((amount) => {
+    if (typeof amount !== 'number') return '—'
+    const hasFraction = amount % 100 !== 0
+    return `${(amount / 100).toLocaleString('ru-RU', {
+      minimumFractionDigits: hasFraction ? 2 : 0,
+      maximumFractionDigits: hasFraction ? 2 : 0,
+    })} ₽`
+  }, [])
+
+  const requirePaidEvent = referralProgram.requirePaidEvent ?? false
+
+  const conditionText = useMemo(
+    () =>
+      requirePaidEvent
+        ? 'Посещение платного мероприятия'
+        : 'Посещение любого мероприятия',
+    [requirePaidEvent]
+  )
+
+  const referrals = useMemo(() => {
+    if (!Array.isArray(users) || !loggedUser?._id) return []
+    return users.filter(
+      (user) =>
+        user?.referrerId && String(user.referrerId) === String(loggedUser._id)
+    )
+  }, [users, loggedUser?._id])
+
+  const sortedReferrals = useMemo(() => {
+    return [...referrals].sort((a, b) => {
+      const dateA = a?.createdAt ? new Date(a.createdAt).getTime() : 0
+      const dateB = b?.createdAt ? new Date(b.createdAt).getTime() : 0
+      return dateB - dateA
+    })
+  }, [referrals])
+
+  const eventsById = useMemo(() => {
+    const map = new Map()
+    if (Array.isArray(events)) {
+      events.forEach((eventItem) => {
+        if (eventItem?._id) {
+          map.set(String(eventItem._id), eventItem)
+        }
+      })
+    }
+    return map
+  }, [events])
+
+  const participantsByUser = useMemo(() => {
+    const map = new Map()
+    if (!Array.isArray(eventsUsers)) return map
+
+    eventsUsers.forEach((eventUser) => {
+      if (!eventUser?.userId) return
+      if (['reserve', 'ban'].includes(eventUser.status)) return
+
+      const userId = String(eventUser.userId)
+      if (map.has(userId)) {
+        map.get(userId).push(eventUser)
+      } else {
+        map.set(userId, [eventUser])
+      }
+    })
+
+    return map
+  }, [eventsUsers])
+
+  const conditionStatusByUser = useMemo(() => {
+    const map = new Map()
+    if (participantsByUser.size === 0) return map
+
+    participantsByUser.forEach((userEvents, userId) => {
+      const hasQualifyingEvent = userEvents.some((eventUser) => {
+        const event = eventsById.get(String(eventUser.eventId))
+        if (!event || event.status !== 'closed') return false
+
+        if (requirePaidEvent) {
+          const isPaidEvent =
+            Array.isArray(event.subEvents) &&
+            event.subEvents.some(
+              (subEvent) => Number(subEvent?.price ?? 0) > 0
+            )
+          if (!isPaidEvent) return false
+        }
+
+        return true
+      })
+
+      map.set(userId, hasQualifyingEvent)
+    })
+
+    return map
+  }, [participantsByUser, eventsById, requirePaidEvent])
+
+  const handleCopy = useCallback(async () => {
+    if (!referralLink) return
+
+    try {
+      await navigator.clipboard.writeText(referralLink)
+      success('Реферальная ссылка скопирована в буфер обмена')
+    } catch (copyError) {
+      error('Не удалось автоматически скопировать ссылку')
+    }
+  }, [referralLink, success, error])
+
+  const handleQrCode = useCallback(() => {
+    if (!referralLink || !modalsFunc?.external?.qrCodeGenerator) return
+
+    modalsFunc.external.qrCodeGenerator({
+      title: 'QR-код реферальной ссылки',
+      link: referralLink,
+    })
+  }, [modalsFunc, referralLink])
+
+  const handleOpenReferral = useCallback(
+    (userId) => {
+      if (!location || !userId) return
+      router.push(`/${location}/user/${userId}`)
+    },
+    [router, location]
+  )
+
+  if (!loggedUser?._id) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <LoadingSpinner text="Загрузка профиля..." />
+      </div>
+    )
+  }
+
+  if (!Array.isArray(users)) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <LoadingSpinner text="Загрузка списка пользователей..." />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4 px-1 pb-4">
+      <div className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+        <div className="text-lg font-semibold text-general">
+          Ваша реферальная ссылка
+        </div>
+        <div className="mt-2 text-sm break-all text-gray-700">
+          {referralLink || 'Ссылка появится после загрузки данных пользователя'}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 mt-3">
+          <Button
+            name="Скопировать ссылку"
+            onClick={handleCopy}
+            disabled={!referralLink}
+          />
+          <Button
+            name="QR код"
+            outline
+            classOutlineColor="border-general"
+            classOutlineTextColor="text-general"
+            classHoverOutlineColor="hover:border-general"
+            classHoverOutlineTextColor="hover:text-general"
+            onClick={handleQrCode}
+            disabled={!referralLink}
+          />
+        </div>
+        <Note className="mt-3">
+          Поделитесь этой ссылкой с друзьями. После регистрации по ней вы
+          увидите их в списке своих рефералов.
+        </Note>
+      </div>
+
+      <div className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+        <div className="text-lg font-semibold text-general">
+          Условия программы
+        </div>
+        <div className="mt-2 text-sm text-gray-700">
+          Условие для получения купона: {conditionText}.
+        </div>
+        <div className="mt-1 text-sm text-gray-700">
+          Купон для реферала: {formatCurrency(referralProgram.referralCouponAmount ?? 0)}.
+        </div>
+        <div className="mt-1 text-sm text-gray-700">
+          Купон для реферера: {formatCurrency(referralProgram.referrerCouponAmount ?? 0)}.
+        </div>
+      </div>
+
+      <div className="p-4 bg-white border border-gray-200 rounded-lg shadow-sm">
+        <div className="flex items-center justify-between">
+          <div className="text-lg font-semibold text-general">
+            Мои рефералы
+          </div>
+          <div className="text-sm text-gray-600">
+            {sortedReferrals.length}{' '}
+            {sortedReferrals.length === 1
+              ? 'приглашенный пользователь'
+              : 'приглашенных пользователей'}
+          </div>
+        </div>
+        {sortedReferrals.length === 0 ? (
+          <div className="mt-4 text-gray-600">
+            Пока нет пользователей, зарегистрировавшихся по вашей ссылке.
+          </div>
+        ) : (
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full text-left border border-gray-200 divide-y divide-gray-200 rounded-lg">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-sm font-medium text-gray-600">
+                    Имя
+                  </th>
+                  <th className="px-4 py-2 text-sm font-medium text-gray-600">
+                    Телефон
+                  </th>
+                  <th className="px-4 py-2 text-sm font-medium text-gray-600">
+                    Дата регистрации
+                  </th>
+                  <th className="px-4 py-2 text-sm font-medium text-gray-600">
+                    Статус условия
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {sortedReferrals.map((user) => {
+                  const conditionMet =
+                    conditionStatusByUser.get(String(user._id)) ?? false
+
+                  return (
+                    <tr
+                      key={user._id}
+                      className="transition-colors cursor-pointer hover:bg-gray-50"
+                      onClick={() => handleOpenReferral(user._id)}
+                    >
+                      <td className="px-4 py-2 text-sm text-gray-700">
+                        <UserName user={user} />
+                      </td>
+                      <td className="px-4 py-2 text-sm text-gray-700">
+                        {user.phone ? `+${user.phone}` : '—'}
+                      </td>
+                      <td className="px-4 py-2 text-sm text-gray-700">
+                        {user.createdAt ? formatDate(user.createdAt) : '—'}
+                      </td>
+                      <td className="px-4 py-2 text-sm text-gray-700">
+                        <div className="flex items-center gap-2">
+                          <FontAwesomeIcon
+                            icon={conditionMet ? faCheckCircle : faTimesCircle}
+                            className={conditionMet ? 'text-success' : 'text-danger'}
+                          />
+                          <span>{conditionMet ? 'Выполнено' : 'Не выполнено'}</span>
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default ReferralsContent

--- a/layouts/content/SettingsReferralSystemContent.js
+++ b/layouts/content/SettingsReferralSystemContent.js
@@ -1,0 +1,181 @@
+'use client'
+
+import Button from '@components/Button'
+import CheckBox from '@components/CheckBox'
+import FormWrapper from '@components/FormWrapper'
+import Note from '@components/Note'
+import PriceInput from '@components/PriceInput'
+import { postData } from '@helpers/CRUD'
+import loggedUserActiveAtom from '@state/atoms/loggedUserActiveAtom'
+import locationAtom from '@state/atoms/locationAtom'
+import siteSettingsAtom from '@state/atoms/siteSettingsAtom'
+import { useEffect, useMemo, useState } from 'react'
+import { useAtom, useAtomValue } from 'jotai'
+
+const SettingsReferralSystemContent = () => {
+  const location = useAtomValue(locationAtom)
+  const loggedUser = useAtomValue(loggedUserActiveAtom)
+  const [siteSettings, setSiteSettings] = useAtom(siteSettingsAtom)
+
+  const [referrerCouponAmount, setReferrerCouponAmount] = useState(0)
+  const [referralCouponAmount, setReferralCouponAmount] = useState(0)
+  const [requirePaidEvent, setRequirePaidEvent] = useState(false)
+  const [enabledForCenter, setEnabledForCenter] = useState(false)
+  const [enabledForClub, setEnabledForClub] = useState(false)
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+
+  const currentProgram = siteSettings?.referralProgram ?? {}
+  const normalizedCenterEnabled =
+    typeof currentProgram.enabledForCenter === 'boolean'
+      ? currentProgram.enabledForCenter
+      : currentProgram.enabled === true
+  const normalizedClubEnabled =
+    typeof currentProgram.enabledForClub === 'boolean'
+      ? currentProgram.enabledForClub
+      : currentProgram.enabled === true
+
+  useEffect(() => {
+    setEnabledForCenter(normalizedCenterEnabled)
+    setEnabledForClub(normalizedClubEnabled)
+    setReferrerCouponAmount(currentProgram.referrerCouponAmount ?? 0)
+    setReferralCouponAmount(currentProgram.referralCouponAmount ?? 0)
+    setRequirePaidEvent(currentProgram.requirePaidEvent ?? false)
+  }, [
+    normalizedCenterEnabled,
+    normalizedClubEnabled,
+    currentProgram.referrerCouponAmount,
+    currentProgram.referralCouponAmount,
+    currentProgram.requirePaidEvent,
+  ])
+
+  const formChanged = useMemo(() => {
+    return (
+      normalizedCenterEnabled !== enabledForCenter ||
+      normalizedClubEnabled !== enabledForClub ||
+      (currentProgram.referrerCouponAmount ?? 0) !== referrerCouponAmount ||
+      (currentProgram.referralCouponAmount ?? 0) !== referralCouponAmount ||
+      (currentProgram.requirePaidEvent ?? false) !== requirePaidEvent
+    )
+  }, [
+    normalizedCenterEnabled,
+    normalizedClubEnabled,
+    currentProgram.referrerCouponAmount,
+    currentProgram.referralCouponAmount,
+    currentProgram.requirePaidEvent,
+    referrerCouponAmount,
+    referralCouponAmount,
+    requirePaidEvent,
+    enabledForCenter,
+    enabledForClub,
+  ])
+
+  const amountsZero = referrerCouponAmount === 0 && referralCouponAmount === 0
+  const programEnabled = enabledForCenter || enabledForClub
+  const applyDisabled =
+    !formChanged || isSaving || (programEnabled && amountsZero)
+  const showZeroWarning = amountsZero && programEnabled
+
+  const handleSave = async () => {
+    if (!location) return
+    if (programEnabled && amountsZero) {
+      setMessage('')
+      setError(
+        'Нельзя включить реферальную систему для Центра или Клуба, если суммы купонов для реферала и реферера равны нулю.'
+      )
+      return
+    }
+
+    setIsSaving(true)
+    setMessage('')
+    setError('')
+
+    await postData(
+      `/api/${location}/site`,
+      {
+        referralProgram: {
+          enabled: programEnabled,
+          enabledForCenter,
+          enabledForClub,
+          referrerCouponAmount,
+          referralCouponAmount,
+          requirePaidEvent,
+        },
+      },
+      (data) => {
+        setSiteSettings(data)
+        setMessage('Настройки обновлены успешно')
+        setIsSaving(false)
+      },
+      () => {
+        setError('Не удалось обновить настройки. Попробуйте ещё раз.')
+        setIsSaving(false)
+      },
+      false,
+      loggedUser?._id
+    )
+  }
+
+  return (
+    <div className="flex flex-col flex-1 h-screen px-2 my-2 gap-y-2">
+      <div className="flex items-center w-full p-1 gap-x-1">
+        <div className="flex flex-row-reverse flex-1">
+          {formChanged && (
+            <span className="leading-4 text-right tablet:text-lg">
+              Чтобы изменения вступили в силу нажмите:
+            </span>
+          )}
+        </div>
+        <Button
+          name="Применить"
+          disabled={applyDisabled}
+          loading={isSaving}
+          onClick={handleSave}
+        />
+      </div>
+      {error && <div className="text-danger">{error}</div>}
+      {message && !isSaving && <div className="text-success">{message}</div>}
+      <FormWrapper>
+        <CheckBox
+          checked={enabledForCenter}
+          label="Для Центра"
+          onClick={() => setEnabledForCenter((state) => !state)}
+        />
+        <CheckBox
+          checked={enabledForClub}
+          label="Для Клуба"
+          onClick={() => setEnabledForClub((state) => !state)}
+        />
+        {showZeroWarning && (
+          <Note className="!text-danger">
+            Нельзя включить реферальную систему для Центра или Клуба с
+            нулевыми суммами купонов для реферала и реферера.
+          </Note>
+        )}
+        <PriceInput
+          label="Сумма купона для реферера"
+          value={referrerCouponAmount}
+          onChange={setReferrerCouponAmount}
+        />
+        <PriceInput
+          label="Сумма купона для реферала"
+          value={referralCouponAmount}
+          onChange={setReferralCouponAmount}
+        />
+        <CheckBox
+          checked={requirePaidEvent}
+          label="Купоны выдаются только за посещение платного мероприятия"
+          onClick={() => setRequirePaidEvent((state) => !state)}
+        />
+        <Note className="mt-2">
+          Значения указываются в рублях. Купоны будут автоматически выдаваться
+          при закрытии мероприятия, если приглашённый пользователь посещает его
+          впервые и выполняет выбранные условия.
+        </Note>
+      </FormWrapper>
+    </div>
+  )
+}
+
+export default SettingsReferralSystemContent

--- a/layouts/content/SettingsRolesContent.js
+++ b/layouts/content/SettingsRolesContent.js
@@ -426,6 +426,11 @@ const SettingsRolesContent = (props) => {
               subItem="fabMenu"
             />
             <RoleItem
+              label="Настройки реферальной системы"
+              item="siteSettings"
+              subItem="referralSystem"
+            />
+            <RoleItem
               label="Редактирование ролей"
               item="siteSettings"
               subItem="roles"

--- a/layouts/modals/modalsFunc/qrCodeGeneratorFunc.js
+++ b/layouts/modals/modalsFunc/qrCodeGeneratorFunc.js
@@ -3,7 +3,7 @@ import { useAtomValue } from 'jotai'
 import locationAtom from '@state/atoms/locationAtom'
 import { useRouter } from 'next/router'
 
-const qrCodeGeneratorFunc = ({ type, id, title }) => {
+const qrCodeGeneratorFunc = ({ type, id, title, link }) => {
   const QRCodeGeneratorFuncModal = ({
     closeModal,
     setOnConfirmFunc,
@@ -19,12 +19,19 @@ const qrCodeGeneratorFunc = ({ type, id, title }) => {
         ? window.location.origin
         : ''
 
+    const targetLink = link
+      ? link
+      : `${origin ? `${origin}/` : '/'}${location}/cabinet/${
+          type ?? router.query.page
+        }${id ? `?id=${id}` : ''}`
+    const encodedLink = encodeURIComponent(targetLink)
+
     return (
       <FormWrapper flex className="flex justify-center">
         {/* <div className="relative"> */}
         <img
           className="max-w-[300px] aspect-1 w-full"
-          src={`https://api.qrserver.com/v1/create-qr-code/?data=${origin}/${location}/cabinet/${type ?? router.query.page}${id ? `?id=${id}` : ''}&amp;size=300x300`}
+          src={`https://api.qrserver.com/v1/create-qr-code/?data=${encodedLink}&size=300x300`}
           alt="qr-code"
         />
         {/* <Image

--- a/pages/[location]/cabinet/[page].js
+++ b/pages/[location]/cabinet/[page].js
@@ -75,7 +75,8 @@ function CabinetPage(props) {
           !CONTENTS[page] ||
           !CONTENTS[page].roleAccess(
             loggedUserActiveRole,
-            loggedUserActiveStatusName
+            loggedUserActiveStatusName,
+            props.siteSettings
           ))) ||
       (typeof CONTENTS[page]?.siteConfirm === 'function' &&
         !CONTENTS[page].siteConfirm(props.siteSettings))

--- a/pages/[location]/login.js
+++ b/pages/[location]/login.js
@@ -364,6 +364,12 @@ const LoginPage = (props) => {
 
   const { location } = props
 
+  const referralId = useMemo(() => {
+    const value = router.query?.ref ?? router.query?.referrer
+    if (Array.isArray(value)) return value[0]
+    return typeof value === 'string' ? value : undefined
+  }, [router.query])
+
   const [process, setProcess] = useState('authorization')
   const [type, setType] = useState()
   const [registrationLevel, setRegistrationLevel] = useState(1)
@@ -428,6 +434,7 @@ const LoginPage = (props) => {
           username: username === 'undefined' ? undefined : username,
           registration: forceReg || isRegistration ? 'true' : 'false',
           location,
+          referrerId: referralId,
         }).then((res) => {
           if (res?.error === 'CredentialsSignin') {
             setWaitingResponse(false)
@@ -461,6 +468,7 @@ const LoginPage = (props) => {
       setTelegramRegistrationConfirm,
       setWaitingResponse,
       setInputPassword,
+      referralId,
     ]
   )
 
@@ -800,6 +808,7 @@ const LoginPage = (props) => {
             forgotPassword: isForgotPassword,
             soctag,
             custag,
+            referrerId: referralId,
           },
           (res) => {
             if (res.error) {

--- a/schemas/paymentsSchema.js
+++ b/schemas/paymentsSchema.js
@@ -68,6 +68,19 @@ const paymentsSchema = {
     type: String,
     default: '',
   },
+  isReferralCoupon: {
+    type: Boolean,
+    default: false,
+  },
+  referralReward: {
+    type: {
+      eventId: { type: String, default: null },
+      referralUserId: { type: String, default: null },
+      referrerId: { type: String, default: null },
+      rewardFor: { type: String, default: null },
+    },
+    default: null,
+  },
 }
 
 export default paymentsSchema

--- a/schemas/rolesSchema.js
+++ b/schemas/rolesSchema.js
@@ -160,6 +160,7 @@ const rolesSchema = {
     default: {
       phoneConfirmService: false,
       fabMenu: false,
+      referralSystem: false,
       roles: false,
     },
   },

--- a/schemas/siteSettingsSchema.js
+++ b/schemas/siteSettingsSchema.js
@@ -81,6 +81,24 @@ const siteSettingsSchema = {
       default: [],
     },
   },
+  referralProgram: {
+    type: {
+      enabled: { type: Boolean, default: false },
+      enabledForCenter: { type: Boolean, default: false },
+      enabledForClub: { type: Boolean, default: false },
+      referrerCouponAmount: { type: Number, default: 0 },
+      referralCouponAmount: { type: Number, default: 0 },
+      requirePaidEvent: { type: Boolean, default: false },
+    },
+    default: {
+      enabled: false,
+      enabledForCenter: false,
+      enabledForClub: false,
+      referrerCouponAmount: 0,
+      referralCouponAmount: 0,
+      requirePaidEvent: false,
+    },
+  },
   title: {
     type: String,
     default: 'Центр серёзных знакомств',

--- a/schemas/usersSchema.js
+++ b/schemas/usersSchema.js
@@ -127,6 +127,11 @@ const usersSchema = {
     type: String,
     default: 'novice',
   },
+  referrerId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Users',
+    default: null,
+  },
   lastActivityAt: {
     type: Date,
     default: () => Date.now(),

--- a/server/CRUD.js
+++ b/server/CRUD.js
@@ -19,6 +19,7 @@ import getGoogleCalendarConstantsByLocation from './getGoogleCalendarConstantsBy
 import checkLocationValid from './checkLocationValid'
 import refreshSignedUpEventsCount from './refreshSignedUpEventsCount'
 // import { telegramCmdToIndex } from './telegramCmd'
+import processReferralRewards from './processReferralRewards'
 
 function isJson(str) {
   try {
@@ -697,6 +698,18 @@ export default async function handler(Schema, req, res, props = {}) {
             // if (!oldData.showOnSite && data.showOnSite) {
             //   notificateUsersAboutEvent(data, req)
             // }
+          }
+
+          if (
+            Schema === 'Events' &&
+            oldData.status !== 'closed' &&
+            data.status === 'closed'
+          ) {
+            try {
+              await processReferralRewards({ db, event: data })
+            } catch (rewardError) {
+              console.log('processReferralRewards error :>> ', rewardError)
+            }
           }
 
           if (

--- a/server/processReferralRewards.js
+++ b/server/processReferralRewards.js
@@ -1,0 +1,188 @@
+const QUALIFYING_STATUSES = ['participant', 'assistant']
+const EXCLUDED_STATUSES = ['reserve', 'ban']
+
+const isPaidEvent = (event) =>
+  Array.isArray(event?.subEvents) &&
+  event.subEvents.some((subEvent) => Number(subEvent?.price ?? 0) > 0)
+
+const getReferralProgramFlags = (referralProgram = {}) => {
+  const fallbackEnabled = referralProgram?.enabled === true
+  const enabledForCenter =
+    typeof referralProgram?.enabledForCenter === 'boolean'
+      ? referralProgram.enabledForCenter
+      : fallbackEnabled
+  const enabledForClub =
+    typeof referralProgram?.enabledForClub === 'boolean'
+      ? referralProgram.enabledForClub
+      : fallbackEnabled
+
+  return {
+    enabledForCenter,
+    enabledForClub,
+    isEnabled: enabledForCenter || enabledForClub,
+  }
+}
+
+const isStatusEligibleForProgram = (flags, status) => {
+  if (!flags) return false
+  if (status === 'member') return flags.enabledForClub
+  return flags.enabledForCenter
+}
+
+const getUserName = (user) =>
+  [user?.firstName, user?.secondName].filter(Boolean).join(' ').trim()
+
+const toStringOrNull = (value) => (value ? String(value) : null)
+
+export default async function processReferralRewards({ db, event }) {
+  if (!db || !event?._id) return
+
+  const eventId = String(event._id)
+
+  try {
+    const siteSettings = await db.model('SiteSettings').findOne({}).lean()
+    const referralProgram = siteSettings?.referralProgram ?? {}
+    const referralProgramFlags = getReferralProgramFlags(referralProgram)
+    if (!referralProgramFlags.isEnabled) return
+    const referrerCouponAmount = referralProgram.referrerCouponAmount ?? 0
+    const referralCouponAmount = referralProgram.referralCouponAmount ?? 0
+    const requirePaidEvent = referralProgram.requirePaidEvent ?? false
+
+    if (!referrerCouponAmount && !referralCouponAmount) return
+
+    if (requirePaidEvent && !isPaidEvent(event)) return
+
+    const eventParticipants = await db
+      .model('EventsUsers')
+      .find({
+        eventId,
+        status: { $in: QUALIFYING_STATUSES },
+      })
+      .lean()
+
+    if (!eventParticipants.length) return
+
+    const closedEvents = await db
+      .model('Events')
+      .find({ status: 'closed' }, { _id: 1 })
+      .lean()
+
+    const otherClosedEventIds = closedEvents
+      .map(({ _id }) => String(_id))
+      .filter((id) => id && id !== eventId)
+
+    const referrerCache = new Map()
+
+    for (const participant of eventParticipants) {
+      const userId = toStringOrNull(participant?.userId)
+      if (!userId) continue
+
+      if (otherClosedEventIds.length) {
+        const hasPreviousClosedEvent = await db.model('EventsUsers').exists({
+          userId,
+          eventId: { $in: otherClosedEventIds },
+          status: { $nin: EXCLUDED_STATUSES },
+        })
+
+        if (hasPreviousClosedEvent) continue
+      }
+
+      const user = await db.model('Users').findById(userId).lean()
+      if (!user) continue
+
+      const userStatus = user.status ?? 'novice'
+      if (!isStatusEligibleForProgram(referralProgramFlags, userStatus)) {
+        continue
+      }
+
+      const referrerId = toStringOrNull(user.referrerId)
+      const referralUserName = getUserName(user)
+      const referralNameSuffix = referralUserName ? ` (${referralUserName})` : ''
+
+      let referrerEligible = false
+      if (referrerId) {
+        let referrer = referrerCache.get(referrerId)
+        if (!referrer) {
+          referrer = await db.model('Users').findById(referrerId).lean()
+          if (referrer) {
+            referrerCache.set(referrerId, referrer)
+          }
+        }
+
+        if (referrer) {
+          referrerEligible = isStatusEligibleForProgram(
+            referralProgramFlags,
+            referrer.status ?? 'novice'
+          )
+        }
+      }
+
+      if (referralCouponAmount > 0) {
+        const referralCouponExists = await db.model('Payments').findOne({
+          userId,
+          'referralReward.eventId': eventId,
+          'referralReward.referralUserId': userId,
+          'referralReward.rewardFor': 'referral',
+          isReferralCoupon: true,
+        })
+
+        if (!referralCouponExists) {
+          await db.model('Payments').create({
+            sector: 'event',
+            payDirection: 'toUser',
+            userId,
+            eventId,
+            payType: 'coupon',
+            sum: referralCouponAmount,
+            payAt: new Date(),
+            comment: `Реферальный купон за первое посещение мероприятия "${
+              event.title ?? ''
+            }"${referralNameSuffix}`,
+            isReferralCoupon: true,
+            referralReward: {
+              eventId,
+              referralUserId: userId,
+              referrerId,
+              rewardFor: 'referral',
+            },
+          })
+        }
+      }
+
+      if (referrerCouponAmount > 0 && referrerId && referrerEligible) {
+        const referrerCouponExists = await db.model('Payments').findOne({
+          userId: referrerId,
+          'referralReward.eventId': eventId,
+          'referralReward.referralUserId': userId,
+          'referralReward.rewardFor': 'referrer',
+          isReferralCoupon: true,
+        })
+
+        if (!referrerCouponExists) {
+          await db.model('Payments').create({
+            sector: 'event',
+            payDirection: 'toUser',
+            userId: referrerId,
+            eventId,
+            payType: 'coupon',
+            sum: referrerCouponAmount,
+            payAt: new Date(),
+            comment: `Купон за приглашённого участника${referralNameSuffix} на мероприятие "${
+              event.title ?? ''
+            }"`,
+            isReferralCoupon: true,
+            referralReward: {
+              eventId,
+              referralUserId: userId,
+              referrerId,
+              rewardFor: 'referrer',
+            },
+          })
+        }
+      }
+    }
+  } catch (error) {
+    console.log('processReferralRewards error :>> ', error)
+    throw error
+  }
+}

--- a/state/atoms/siteSettingsAtom.js
+++ b/state/atoms/siteSettingsAtom.js
@@ -10,6 +10,14 @@ const siteSettingsAtom = atom({
   telegram: null,
   instagram: null,
   vk: null,
+  referralProgram: {
+    enabled: false,
+    enabledForCenter: false,
+    enabledForClub: false,
+    referrerCouponAmount: 0,
+    referralCouponAmount: 0,
+    requirePaidEvent: false,
+  },
 })
 
 export default siteSettingsAtom

--- a/state/modalsFuncAtom.js
+++ b/state/modalsFuncAtom.js
@@ -854,12 +854,13 @@ const modalsFuncGenerator = (get, set) => {
         )
       ),
     external: {
-      qrCodeGenerator: ({ type, id, title }) =>
+      qrCodeGenerator: ({ type, id, title, link }) =>
         addModal(
           require('../layouts/modals/modalsFunc/qrCodeGeneratorFunc').default({
             type,
             id,
             title,
+            link,
           })
         ),
       ai: () =>


### PR DESCRIPTION
## Summary
- add separate "center" and "club" toggles to referral settings along with schema and state defaults
- hide the referrals menu for clients whose status is not enabled and use the new toggles while issuing rewards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6bf8610e88329bbcffef353f4ec6f