### PR TITLE
Fix null status access in event signup modals

### DIFF
--- a/layouts/modals/modalsFunc/eventSignUpFunc.js
+++ b/layouts/modals/modalsFunc/eventSignUpFunc.js
@@ -61,7 +61,7 @@ const eventSignUpFunc = (
           eventId,
           userId: loggedUserActive?._id,
           status,
-          userStatus: loggedUserActive.status,
+          userStatus: loggedUserActive?.status,
           comment,
           subEventId,
         },

--- a/layouts/modals/modalsFunc/eventSignUpToReserveAfterError.js
+++ b/layouts/modals/modalsFunc/eventSignUpToReserveAfterError.js
@@ -31,7 +31,7 @@ const eventSignUpToReserveAfterError = (event, error, comment, subEventId) => {
           eventId,
           userId: loggedUserActive?._id,
           status: 'reserve',
-          userStatus: loggedUserActive.status,
+          userStatus: loggedUserActive?.status,
           comment,
           subEventId,
         },


### PR DESCRIPTION
## Summary
- avoid dereferencing the logged in user when it is not yet loaded in the event signup modal
- apply the same null-safe access when offering a reserve signup retry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d95d6c352c8329b58697f9470f7501