### PR TITLE
Prevent event view modal from reading undefined status

### DIFF
--- a/layouts/modals/modalsFunc/eventSignUpFunc.js
+++ b/layouts/modals/modalsFunc/eventSignUpFunc.js
@@ -61,7 +61,7 @@ const eventSignUpFunc = (
           eventId,
           userId: loggedUserActive?._id,
           status,
-          userStatus: loggedUserActive.status,
+          userStatus: loggedUserActive?.status,
           comment,
           subEventId,
         },

--- a/layouts/modals/modalsFunc/eventSignUpToReserveAfterError.js
+++ b/layouts/modals/modalsFunc/eventSignUpToReserveAfterError.js
@@ -31,7 +31,7 @@ const eventSignUpToReserveAfterError = (event, error, comment, subEventId) => {
           eventId,
           userId: loggedUserActive?._id,
           status: 'reserve',
-          userStatus: loggedUserActive.status,
+          userStatus: loggedUserActive?.status,
           comment,
           subEventId,
         },

--- a/layouts/modals/modalsFunc/eventViewFunc.js
+++ b/layouts/modals/modalsFunc/eventViewFunc.js
@@ -282,10 +282,11 @@ const EventView = (props) => {
   const event = useAtomValue(eventSelector(eventId))
 
   const loggedUserActive = useAtomValue(loggedUserActiveAtom)
-  const { canSee, isAgeOfUserCorrect, isUserStatusCorrect, status } =
-    useAtomValue(loggedUserToEventStatusSelector(event?._id))
+  const { canSee, isAgeOfUserCorrect, isUserStatusCorrect } =
+    useAtomValue(loggedUserToEventStatusSelector(event?._id)) ?? {}
 
-  const subEventSum = useAtomValue(subEventsSumOfEventSelector(event._id))
+  const subEventSum =
+    useAtomValue(subEventsSumOfEventSelector(event?._id)) ?? {}
 
   const router = useRouter()
   const routerQuery = { ...router.query }
@@ -299,11 +300,14 @@ const EventView = (props) => {
     <EventViewModal {...props} />
   ) : (
     <div className="flex flex-col items-center">
-      {loggedUserActive && !isUserStatusCorrect ? (
+      {loggedUserActive && isUserStatusCorrect === false ? (
         <span className="text-xl">
           {`К сожалению данное мероприятие не доступно для вашего статуса пользователя`}
         </span>
-      ) : loggedUserActive && isUserStatusCorrect && !isAgeOfUserCorrect ? (
+      ) :
+      loggedUserActive &&
+      isUserStatusCorrect !== false &&
+      isAgeOfUserCorrect === false ? (
         <span className="text-xl">
           {`К сожалению данное мероприятие доступно для возрастной категории ${
             loggedUserActive?.gender === 'male'
@@ -311,7 +315,10 @@ const EventView = (props) => {
               : `женщин от ${subEventSum.minWomansAge} до ${subEventSum.maxWomansAge} лет`
           }`}
         </span>
-      ) : !canSee && isUserStatusCorrect && isAgeOfUserCorrect ? (
+      ) :
+      canSee === false &&
+      isUserStatusCorrect !== false &&
+      isAgeOfUserCorrect !== false ? (
         <span className="text-xl">
           Мероприятие скрыто, если вы не ошиблись со ссылкой, то пожалуйста
           обратитесь к администратору


### PR DESCRIPTION
## Summary
- default the logged-user event status lookup to an empty object while the data is loading
- guard the sub-event summary lookup in the event view modal until the event id is known
- treat status flags as explicit booleans to avoid flashing the wrong restriction message during loading

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d95d6c352c8329b58697f9470f7501