### PR TITLE
Fix referral coupon usage detection in referral list

### DIFF
--- a/layouts/content/ReferralsContent.js
+++ b/layouts/content/ReferralsContent.js
@@ -180,27 +180,29 @@ const ReferralsContent = () => {
       const referralKey = String(referralUserId)
       const existingDetails = map.get(referralKey) ?? {}
 
+      const paymentEventId =
+        payment?.eventId != null ? String(payment.eventId) : null
+      const rewardEventId =
+        reward?.eventId != null ? String(reward.eventId) : null
+
       const couponDetails = {
         sum: typeof payment?.sum === 'number' ? payment.sum : null,
         payAt: payment?.payAt ?? null,
-        eventId: payment?.eventId ?? reward?.eventId ?? null,
+        rewardEventId,
+        usageEventId: paymentEventId,
         comment: payment?.comment ?? '',
       }
 
-      if (payment?.payDirection === 'fromUser') {
+      if (paymentEventId) {
         map.set(referralKey, {
           ...existingDetails,
           used: couponDetails,
-        })
-      } else if (payment?.payDirection === 'toUser') {
-        map.set(referralKey, {
-          ...existingDetails,
-          issued: couponDetails,
+          issued: existingDetails.issued ?? null,
         })
       } else {
         map.set(referralKey, {
           ...existingDetails,
-          issued: existingDetails.issued ?? couponDetails,
+          issued: couponDetails,
         })
       }
     })
@@ -358,7 +360,8 @@ const ReferralsContent = () => {
                         .replace(/\s+руб/, ' руб')
                         .trim()
                     : null
-                  const usageEventId = usedCoupon?.eventId
+                  const usageEventId =
+                    usedCoupon?.usageEventId ?? usedCoupon?.eventId ?? null
                   const usageEvent = usageEventId
                     ? eventsById.get(String(usageEventId))
                     : null


### PR DESCRIPTION
## Summary
- categorize referral reward coupons by issuance versus usage based on whether they are linked to an event
- show the usage event for referrer coupons only when the referrer actually spent the coupon

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e001626ac88329a0173d00e7ad5065