### PR TITLE
Add client-side error logging pipeline

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -31,6 +31,9 @@ import localFont from 'next/font/local'
 import PWAChecker from '@components/PWAChecker'
 import { Provider as JotaiProvider } from 'jotai'
 import store from '@state/store'
+import locationAtom from '@state/atoms/locationAtom'
+import loggedUserActiveAtom from '@state/atoms/loggedUserActiveAtom'
+import { LOCATIONS_KEYS } from '@server/serverConstants'
 
 // Create a theme instance.
 const theme = createTheme({
@@ -248,33 +251,177 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }) {
     })
   }, [])
 
-  // useEffect(() => {
-  //   // Обработчик ошибок
-  //   const handleError = (error, componentStack) => {
-  //     console.error('Client-side error:', { error, componentStack })
-  //     // Отправка на сервер/сохранение в localStorage
-  //   }
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
 
-  //   // Перехватчик ошибок React
-  //   window.onerror = (message, source, lineno, colno, error) => {
-  //     handleError(error, `Line ${lineno}:${colno}`)
-  //     return true // Предотвращаем вывод в консоль по умолчанию
-  //   }
+    let isMounted = true
+    let isReporting = false
+    const queue = []
+    const signatures = new Set()
 
-  //   // Перехватчик необработанных Promise
-  //   window.addEventListener('unhandledrejection', (event) => {
-  //     handleError(event.reason, 'Unhandled Promise Rejection')
-  //   })
+    const safeStringify = (value) => {
+      try {
+        return JSON.stringify(value)
+      } catch (error) {
+        return String(value)
+      }
+    }
 
-  //   // Error Boundary (для классовых компонентов)
-  //   if (typeof window !== 'undefined') {
-  //     const originalConsoleError = console.error
-  //     console.error = (...args) => {
-  //       originalConsoleError.apply(console, args)
-  //       handleError(args[0], 'Console Error')
-  //     }
-  //   }
-  // }, [])
+    const guessLocationFromPath = () => {
+      const pathname = window.location?.pathname ?? ''
+      const [, firstSegment] = pathname.split('/')
+      if (firstSegment && LOCATIONS_KEYS.includes(firstSegment)) {
+        return firstSegment
+      }
+      return null
+    }
+
+    const resolveLocation = () => {
+      try {
+        const location = store.get(locationAtom)
+        if (location) return location
+      } catch (error) {
+        // ignore
+      }
+      return guessLocationFromPath()
+    }
+
+    const resolveUserInfo = () => {
+      try {
+        return store.get(loggedUserActiveAtom) ?? null
+      } catch (error) {
+        return null
+      }
+    }
+
+    const serializeError = (error) => {
+      if (!error) {
+        return { message: 'Unknown error', stack: '', componentStack: '' }
+      }
+      if (error instanceof Error) {
+        return {
+          message: error.message ?? 'Error',
+          stack: error.stack ?? '',
+          componentStack: error.componentStack ?? '',
+        }
+      }
+      if (typeof error === 'string') {
+        return { message: error, stack: '', componentStack: '' }
+      }
+      if (typeof error === 'object') {
+        return {
+          message: error.message ?? safeStringify(error),
+          stack: error.stack ?? '',
+          componentStack: error.componentStack ?? '',
+        }
+      }
+      return { message: String(error), stack: '', componentStack: '' }
+    }
+
+    const processQueue = async () => {
+      if (!isMounted || isReporting || queue.length === 0) return
+      isReporting = true
+      const payload = queue.shift()
+
+      try {
+        const response = await fetch('/api/log', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        })
+
+        if (response.ok) {
+          const result = await response.json()
+          if (result?.data?.id) {
+            console.info('Client error logged', result.data.id)
+            try {
+              sessionStorage.setItem('lastClientErrorLogId', result.data.id)
+            } catch (error) {
+              // ignore storage errors
+            }
+          }
+        } else {
+          console.warn('Failed to log client error', await response.text())
+        }
+      } catch (error) {
+        console.warn('Error while sending client error log', error)
+      } finally {
+        isReporting = false
+        if (queue.length > 0) {
+          processQueue()
+        }
+      }
+    }
+
+    const enqueuePayload = (payload) => {
+      queue.push(payload)
+      void processQueue()
+    }
+
+    const handleError = (error, componentStack = '', meta = {}) => {
+      const location = resolveLocation()
+      if (!location) return
+
+      const serialized = serializeError(error)
+      const payload = {
+        location,
+        error: {
+          message: serialized.message,
+          stack: serialized.stack,
+          componentStack:
+            componentStack || serialized.componentStack || '',
+          url: window.location?.href ?? '',
+          userAgent: navigator?.userAgent ?? '',
+        },
+        user: resolveUserInfo(),
+        meta: { ...meta, timestamp: new Date().toISOString() },
+      }
+
+      const signature = `${location}|${payload.error.message}|${payload.error.stack}|${payload.error.componentStack}`
+      if (signatures.has(signature)) return
+      signatures.add(signature)
+
+      enqueuePayload(payload)
+    }
+
+    const handleWindowError = (message, source, lineno, colno, error) => {
+      handleError(error ?? message, `Line ${lineno}:${colno}`, {
+        type: 'window.onerror',
+        source,
+        lineno,
+        colno,
+      })
+      return false
+    }
+
+    const handleUnhandledRejection = (event) => {
+      handleError(event?.reason, 'Unhandled Promise Rejection', {
+        type: 'unhandledrejection',
+      })
+    }
+
+    const previousOnError = window.onerror
+    window.onerror = (message, source, lineno, colno, error) => {
+      if (typeof previousOnError === 'function') {
+        try {
+          previousOnError(message, source, lineno, colno, error)
+        } catch (prevError) {
+          console.warn('Previous window.onerror handler failed', prevError)
+        }
+      }
+      return handleWindowError(message, source, lineno, colno, error)
+    }
+
+    window.addEventListener('unhandledrejection', handleUnhandledRejection)
+
+    return () => {
+      isMounted = false
+      window.onerror = previousOnError ?? null
+      window.removeEventListener('unhandledrejection', handleUnhandledRejection)
+    }
+  }, [])
 
   // useEffect(() => {
   //   import('preline')

--- a/pages/api/log.js
+++ b/pages/api/log.js
@@ -1,7 +1,48 @@
+import dbConnect from '@utils/dbConnect'
+
 export default async function handler(req, res) {
   const { method, body } = req
-  console.log(`----------------- log -----------------`)
-  console.log(`body`, body)
-  console.log(`----------------- end log -----------------`)
-  return res?.status(200).json({ success: true, data: { method, body } })
+
+  if (method !== 'POST') {
+    return res?.status(405).json({ success: false, error: 'Method not allowed' })
+  }
+
+  const location = body?.location
+  if (!location) {
+    return res?.status(400).json({ success: false, error: 'No location provided' })
+  }
+
+  try {
+    const db = await dbConnect(location)
+    if (!db) {
+      return res?.status(400).json({ success: false, error: 'Database connection error' })
+    }
+
+    const {
+      error = {},
+      user,
+      userInfo,
+      meta,
+      context,
+    } = body ?? {}
+
+    const logEntry = await db.model('ClientErrorLogs').create({
+      message: error?.message ?? '',
+      stack: error?.stack ?? '',
+      componentStack: error?.componentStack ?? '',
+      url: error?.url ?? '',
+      userAgent: error?.userAgent ?? '',
+      location,
+      userInfo: userInfo ?? user ?? error?.user ?? null,
+      meta: meta ?? context ?? error?.meta ?? null,
+    })
+
+    return res?.status(200).json({
+      success: true,
+      data: { id: logEntry?._id },
+    })
+  } catch (error) {
+    console.error('Failed to persist client error log', error)
+    return res?.status(500).json({ success: false, error: 'Failed to log error' })
+  }
 }

--- a/schemas/clientErrorLogsSchema.js
+++ b/schemas/clientErrorLogsSchema.js
@@ -1,0 +1,36 @@
+const clientErrorLogsSchema = {
+  message: {
+    type: String,
+    default: '',
+  },
+  stack: {
+    type: String,
+    default: '',
+  },
+  componentStack: {
+    type: String,
+    default: '',
+  },
+  url: {
+    type: String,
+    default: '',
+  },
+  userAgent: {
+    type: String,
+    default: '',
+  },
+  location: {
+    type: String,
+    default: '',
+  },
+  userInfo: {
+    type: Object,
+    default: null,
+  },
+  meta: {
+    type: Object,
+    default: null,
+  },
+}
+
+export default clientErrorLogsSchema

--- a/utils/dbConnect.js
+++ b/utils/dbConnect.js
@@ -6,6 +6,7 @@ import eventsSchema from '@schemas/eventsSchema'
 import eventsUsersSchema from '@schemas/eventsUsersSchema'
 import historiesSchema from '@schemas/historiesSchema'
 import loginHistorySchema from '@schemas/loginHistorySchema'
+import clientErrorLogsSchema from '@schemas/clientErrorLogsSchema'
 import paymentsSchema from '@schemas/paymentsSchema'
 import phoneConfirmsSchema from '@schemas/phoneConfirmsSchema'
 import productsSchema from '@schemas/productsSchema'
@@ -199,6 +200,10 @@ async function dbConnect(location) {
     connections[location].model(
       'Histories',
       mongoose.Schema(historiesSchema, { timestamps: true })
+    )
+    connections[location].model(
+      'ClientErrorLogs',
+      mongoose.Schema(clientErrorLogsSchema, { timestamps: true })
     )
     connections[location].model(
       'AdditionalBlocks',


### PR DESCRIPTION
## Summary
- add a dedicated schema and model for client-side error logs in each location database
- update the log API to persist reported errors through the location-aware database connection
- enable global client error handlers in the app shell that queue reports and store the created log identifier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e21ab0df488329a1e4e13075f2df57