### PR TITLE
Implement password hashing for user credentials

### DIFF
--- a/helpers/passwordUtils.js
+++ b/helpers/passwordUtils.js
@@ -1,0 +1,65 @@
+import crypto from 'crypto'
+
+const PBKDF2_ITERATIONS = 120000
+const PBKDF2_KEYLEN = 64
+const PBKDF2_DIGEST = 'sha512'
+const HASH_PREFIX = 'pbkdf2'
+
+const pbkdf2Async = (password, salt, iterations, keylen, digest) =>
+  new Promise((resolve, reject) => {
+    crypto.pbkdf2(password, salt, iterations, keylen, digest, (error, derivedKey) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve(derivedKey)
+      }
+    })
+  })
+
+export const isPasswordHashed = (password) =>
+  typeof password === 'string' && password.startsWith(`${HASH_PREFIX}$`)
+
+export const hashPassword = async (password) => {
+  if (typeof password !== 'string' || password.length === 0) return password
+  if (isPasswordHashed(password)) return password
+
+  const salt = crypto.randomBytes(16).toString('hex')
+  const derivedKey = await pbkdf2Async(
+    password,
+    salt,
+    PBKDF2_ITERATIONS,
+    PBKDF2_KEYLEN,
+    PBKDF2_DIGEST
+  )
+
+  return `${HASH_PREFIX}$${PBKDF2_ITERATIONS}$${salt}$${derivedKey.toString('hex')}`
+}
+
+export const verifyPassword = async (password, storedPassword) => {
+  if (typeof password !== 'string' || !storedPassword) return false
+
+  if (!isPasswordHashed(storedPassword)) {
+    return storedPassword === password
+  }
+
+  const [, iterationsRaw, salt, hash] = storedPassword.split('$')
+  const iterations = Number(iterationsRaw)
+
+  if (!iterations || !salt || !hash) return false
+
+  const derivedKey = await pbkdf2Async(
+    password,
+    salt,
+    iterations,
+    hash.length / 2,
+    PBKDF2_DIGEST
+  )
+
+  try {
+    return crypto.timingSafeEqual(Buffer.from(hash, 'hex'), derivedKey)
+  } catch (error) {
+    return false
+  }
+}
+
+export const shouldRehashPassword = (password) => !isPasswordHashed(password)

--- a/pages/api/tools/hash-passwords.js
+++ b/pages/api/tools/hash-passwords.js
@@ -1,0 +1,95 @@
+import { hashPassword, shouldRehashPassword } from '@helpers/passwordUtils'
+import dbConnect from '@utils/dbConnect'
+import { LOCATIONS_KEYS } from '@server/serverConstants'
+
+const AUTH_TOKEN = process.env.PASSWORD_MIGRATION_TOKEN
+
+const validateToken = (providedToken) => {
+  if (!AUTH_TOKEN) return true
+  return providedToken === AUTH_TOKEN
+}
+
+const resolveLocations = (locationParam) => {
+  if (!locationParam) return LOCATIONS_KEYS
+
+  if (Array.isArray(locationParam)) {
+    return locationParam.filter((value) => LOCATIONS_KEYS.includes(value))
+  }
+
+  return LOCATIONS_KEYS.includes(locationParam) ? [locationParam] : []
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ success: false, error: 'Method not allowed' })
+  }
+
+  if (!validateToken(req.query?.token)) {
+    return res.status(401).json({ success: false, error: 'Unauthorized' })
+  }
+
+  const locations = resolveLocations(req.query?.location)
+
+  if (!locations.length) {
+    return res.status(400).json({
+      success: false,
+      error: 'No valid locations provided',
+    })
+  }
+
+  const summary = []
+
+  for (const location of locations) {
+    try {
+      const db = await dbConnect(location)
+
+      if (!db) {
+        summary.push({ location, success: false, error: 'DB connection failed' })
+        continue
+      }
+
+      const usersModel = db.model('Users')
+      const candidates = await usersModel
+        .find({ password: { $nin: [null, ''] } })
+        .select({ password: 1 })
+        .lean()
+
+      let processed = 0
+      let updated = 0
+
+      const operations = []
+
+      for (const candidate of candidates) {
+        processed += 1
+        if (!shouldRehashPassword(candidate.password)) continue
+
+        const newHash = await hashPassword(candidate.password)
+        if (!newHash || newHash === candidate.password) continue
+
+        operations.push({
+          updateOne: {
+            filter: { _id: candidate._id },
+            update: { $set: { password: newHash } },
+          },
+        })
+        updated += 1
+      }
+
+      if (operations.length > 0) {
+        await usersModel.bulkWrite(operations)
+      }
+
+      summary.push({
+        location,
+        success: true,
+        processed,
+        updated,
+      })
+    } catch (error) {
+      console.error('password migration error', location, error)
+      summary.push({ location, success: false, error: error?.message || 'Unknown error' })
+    }
+  }
+
+  return res.status(200).json({ success: true, summary })
+}


### PR DESCRIPTION
## Summary
- add a PBKDF2-based password hashing helper for storing user credentials securely
- hash passwords during registration flows and generic Users CRUD mutations while redacting sensitive logging
- update credential-based authentication to validate hashed passwords and transparently upgrade legacy plain-text records
- add a temporary GET /api/tools/hash-passwords endpoint to batch migrate legacy plain-text passwords with optional token gating

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2a4efe7008329961e75026995da45