### PR TITLE
Add achievements management and user awards

### DIFF
--- a/components/StateLoader.js
+++ b/components/StateLoader.js
@@ -9,6 +9,8 @@ import ModalsPortal from '@layouts/modals/ModalsPortal'
 
 // import itemsFuncGenerator from '@state/itemsFuncGenerator'
 
+import achievementsAtom from '@state/atoms/achievementsAtom'
+import achievementsUsersAtom from '@state/atoms/achievementsUsersAtom'
 import additionalBlocksAtom from '@state/atoms/additionalBlocksAtom'
 import directionsAtom from '@state/atoms/directionsAtom'
 import eventsAtom from '@state/atoms/eventsAtom'
@@ -101,6 +103,8 @@ const StateLoader = (props) => {
   )
   const setEventsState = useSetAtom(eventsAtom)
   const setDirectionsState = useSetAtom(directionsAtom)
+  const setAchievementsState = useSetAtom(achievementsAtom)
+  const setAchievementsUsersState = useSetAtom(achievementsUsersAtom)
   const setAdditionalBlocksState = useSetAtom(additionalBlocksAtom)
   const setUsersState = useSetAtom(usersAtomAsync)
   // const setIsLoadedUsersAtom = useSetAtom(isLoadedAtom('usersAtomAsync'))
@@ -208,6 +212,8 @@ const StateLoader = (props) => {
     setQuestionnairesState(props.questionnaires)
     setQuestionnairesUsersState(props.questionnairesUsers)
     setServicesState(props.services)
+    setAchievementsState(props.achievements ?? [])
+    setAchievementsUsersState(props.achievementsUsers ?? [])
     // setServicesUsersState(props.servicesUsers)
     setServerSettingsState(props.serverSettings)
     setMode(props.mode ?? 'production')

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -164,6 +164,12 @@ const ToolsEventAnonsVkContent = dynamic(
 const IndividualWeddingsContent = dynamic(
   () => import('@layouts/content/IndividualWeddingsContent')
 )
+const MyAchievementsContent = dynamic(
+  () => import('@layouts/content/MyAchievementsContent')
+)
+const SettingsAchievementsContent = dynamic(
+  () => import('@layouts/content/SettingsAchievementsContent')
+)
 
 import ZodiacCapricorn from '@svg/zodiac/ZodiacCapricorn'
 import ZodiacTaurus from '@svg/zodiac/ZodiacTaurus'
@@ -187,6 +193,7 @@ import ReferralsContent from '@layouts/content/ReferralsContent'
 import badgeLoggedUserLikesToSeeSelector from '@state/selectors/badgeLoggedUserLikesToSeeSelector'
 import RemindDatesContent from '@layouts/content/RemindDatesContent'
 import WhatsappMessagesContent from '@layouts/content/WhatsappMessagesContent'
+import menuHiddenLoggedUserAchievementsSelector from '@state/selectors/menuHiddenLoggedUserAchievementsSelector'
 
 // const colors = [
 //   'border-blue-400',
@@ -1055,6 +1062,7 @@ export const DEFAULT_ROLES = [
       phoneConfirmService: false,
       fabMenu: false,
       referralSystem: false,
+      achievements: false,
       roles: false,
       dateStartProject: false,
       headerInfo: false,
@@ -1195,6 +1203,7 @@ export const DEFAULT_ROLES = [
       phoneConfirmService: false,
       fabMenu: false,
       referralSystem: false,
+      achievements: false,
       roles: false,
       dateStartProject: false,
       headerInfo: false,
@@ -1335,6 +1344,7 @@ export const DEFAULT_ROLES = [
       phoneConfirmService: false,
       fabMenu: false,
       referralSystem: false,
+      achievements: false,
       roles: false,
       dateStartProject: false,
       headerInfo: false,
@@ -1475,6 +1485,7 @@ export const DEFAULT_ROLES = [
       phoneConfirmService: false,
       fabMenu: true,
       referralSystem: true,
+      achievements: true,
       roles: true,
       dateStartProject: false,
       headerInfo: true,
@@ -1615,6 +1626,7 @@ export const DEFAULT_ROLES = [
       phoneConfirmService: false,
       fabMenu: true,
       referralSystem: true,
+      achievements: true,
       roles: true,
       dateStartProject: false,
       headerInfo: true,
@@ -1755,6 +1767,7 @@ export const DEFAULT_ROLES = [
       phoneConfirmService: true,
       fabMenu: true,
       referralSystem: true,
+      achievements: true,
       roles: true,
       dateStartProject: true,
       headerInfo: true,
@@ -2086,6 +2099,12 @@ export const CONTENTS = Object.freeze({
     accessRoles: ['supervisor', 'dev'],
     roleAccess: (role) => role?.siteSettings?.fabMenu,
   },
+  settingsAchievements: {
+    Component: SettingsAchievementsContent,
+    name: 'Настройки / Достижения',
+    accessRoles: ['supervisor', 'president', 'dev'],
+    roleAccess: (role) => role?.siteSettings?.achievements,
+  },
   settingsReferralSystem: {
     Component: SettingsReferralSystemContent,
     name: 'Настройки / Реферальная система',
@@ -2109,6 +2128,19 @@ export const CONTENTS = Object.freeze({
     name: 'Настройки / Информация для вступления в клуб',
     accessRoles: ['supervisor', 'dev'],
     roleAccess: (role) => role?.siteSettings?.headerInfo,
+  },
+  myAchievements: {
+    Component: MyAchievementsContent,
+    name: 'Мои достижения',
+    accessRoles: [
+      'client',
+      'moder',
+      'admin',
+      'supervisor',
+      'president',
+      'dev',
+    ],
+    roleAccess: () => true,
   },
   userStatistics: {
     Component: UserStatisticsContent,
@@ -2162,6 +2194,15 @@ export const pages = [
     icon: faTrophy,
     // accessRoles: CONTENTS['userStatistics'].accessRoles,
     roleAccess: CONTENTS['userStatistics'].roleAccess,
+  },
+  {
+    id: 900,
+    group: 0,
+    name: 'Мои достижения',
+    href: 'myAchievements',
+    icon: faMedal,
+    hidden: menuHiddenLoggedUserAchievementsSelector,
+    roleAccess: CONTENTS['myAchievements'].roleAccess,
   },
   {
     id: 1,
@@ -2485,6 +2526,15 @@ export const pages = [
     icon: faQuestion,
     // accessRoles: CONTENTS['settingsFabMenu'].accessRoles,
     roleAccess: CONTENTS['settingsFabMenu'].roleAccess,
+  },
+  {
+    id: 85,
+    group: 11,
+    name: 'Достижения',
+    href: 'settingsAchievements',
+    icon: faMedal,
+    // accessRoles: CONTENTS['settingsAchievements'].accessRoles,
+    roleAccess: CONTENTS['settingsAchievements'].roleAccess,
   },
   {
     id: 86,

--- a/layouts/content/MyAchievementsContent.js
+++ b/layouts/content/MyAchievementsContent.js
@@ -1,0 +1,124 @@
+'use client'
+
+import Image from 'next/image'
+import { useMemo } from 'react'
+import { useAtomValue } from 'jotai'
+
+import achievementsAtom from '@state/atoms/achievementsAtom'
+import achievementsUsersAtom from '@state/atoms/achievementsUsersAtom'
+import eventsAtom from '@state/atoms/eventsAtom'
+import loggedUserActiveAtom from '@state/atoms/loggedUserActiveAtom'
+import formatDateTime from '@helpers/formatDateTime'
+import cn from 'classnames'
+
+const AchievementCard = ({ achievement, issuedAt, event, eventName, comment }) => {
+  const hasImage = Boolean(achievement?.image)
+  const eventTitle = event?.title || event?.name || eventName || ''
+
+  const issuedLabel = issuedAt
+    ? formatDateTime(
+        issuedAt,
+        true,
+        false,
+        false,
+        false,
+        undefined,
+        true,
+        true
+      )
+    : null
+
+  return (
+    <div className="flex flex-col overflow-hidden bg-white border border-gray-200 rounded-xl shadow-sm">
+      {hasImage && (
+        <div className="relative w-full h-40 bg-gray-100">
+          <Image
+            src={achievement.image}
+            alt={achievement?.name ?? 'Достижение'}
+            layout="fill"
+            objectFit="cover"
+            sizes="(max-width: 768px) 100vw, 300px"
+            className="object-cover"
+          />
+        </div>
+      )}
+      <div className={cn('flex flex-col gap-y-2 p-4', { 'pt-4': !hasImage })}>
+        <div className="text-lg font-semibold text-gray-900">
+          {achievement?.name ?? 'Достижение удалено'}
+        </div>
+        {achievement?.description && (
+          <div className="text-sm text-gray-700 whitespace-pre-line">
+            {achievement.description}
+          </div>
+        )}
+        {comment && (
+          <div className="text-sm text-gray-700 whitespace-pre-line">
+            {comment}
+          </div>
+        )}
+        {issuedLabel && (
+          <div className="mt-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+            Выдано {issuedLabel}
+          </div>
+        )}
+        {eventTitle && (
+          <div className="text-sm text-gray-600">
+            Мероприятие: <span className="font-medium text-gray-800">{eventTitle}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const MyAchievementsContent = () => {
+  const loggedUser = useAtomValue(loggedUserActiveAtom)
+  const achievements = useAtomValue(achievementsAtom)
+  const achievementsUsers = useAtomValue(achievementsUsersAtom)
+  const events = useAtomValue(eventsAtom)
+
+  const userAchievements = useMemo(() => {
+    if (!loggedUser?._id) return []
+
+    return achievementsUsers
+      ?.filter((item) => String(item.userId) === String(loggedUser._id))
+      .map((item) => {
+        const achievement = achievements.find(
+          ({ _id }) => String(_id) === String(item.achievementId)
+        )
+        const event = events.find(({ _id }) => String(_id) === String(item.eventId))
+
+        return {
+          ...item,
+          achievement,
+          event,
+        }
+      })
+      .sort((a, b) => new Date(b.issuedAt) - new Date(a.issuedAt))
+  }, [achievementsUsers, achievements, events, loggedUser])
+
+  if (!userAchievements || userAchievements.length === 0) {
+    return (
+      <div className="flex items-center justify-center w-full h-full p-4 text-center text-gray-600">
+        Пока у вас нет достижений. Как только вы их получите, они появятся здесь.
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid w-full max-w-5xl grid-cols-1 gap-4 p-2 mx-auto tablet:grid-cols-2 xl:grid-cols-3">
+      {userAchievements.map((item) => (
+        <AchievementCard
+          key={item._id}
+          achievement={item.achievement}
+          issuedAt={item.issuedAt}
+          event={item.event ?? null}
+          eventName={item.eventName}
+          comment={item.comment}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default MyAchievementsContent

--- a/layouts/content/SettingsAchievementsContent.js
+++ b/layouts/content/SettingsAchievementsContent.js
@@ -1,0 +1,623 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useAtom, useAtomValue } from 'jotai'
+import Image from 'next/image'
+
+import Button from '@components/Button'
+import FormWrapper from '@components/FormWrapper'
+import Input from '@components/Input'
+import InputImage from '@components/InputImage'
+import Textarea from '@components/Textarea'
+import achievementsAtom from '@state/atoms/achievementsAtom'
+import achievementsUsersAtom from '@state/atoms/achievementsUsersAtom'
+import eventsAtom from '@state/atoms/eventsAtom'
+import loggedUserActiveAtom from '@state/atoms/loggedUserActiveAtom'
+import locationAtom from '@state/atoms/locationAtom'
+import modalsFuncAtom from '@state/modalsFuncAtom'
+import usersAtomAsync from '@state/async/usersAtomAsync'
+import { postData, putData, deleteData } from '@helpers/CRUD'
+import useSnackbar from '@helpers/useSnackbar'
+import compareObjects from '@helpers/compareObjects'
+import getUserFullName from '@helpers/getUserFullName'
+import formatDateTime from '@helpers/formatDateTime'
+
+const defaultNewAchievement = {
+  name: '',
+  description: '',
+  image: null,
+}
+
+const SettingsAchievementsContent = () => {
+  const snackbar = useSnackbar()
+  const location = useAtomValue(locationAtom)
+  const loggedUser = useAtomValue(loggedUserActiveAtom)
+  const modalsFunc = useAtomValue(modalsFuncAtom)
+  const events = useAtomValue(eventsAtom)
+  const users = useAtomValue(usersAtomAsync)
+
+  const [achievements, setAchievements] = useAtom(achievementsAtom)
+  const [editedAchievements, setEditedAchievements] = useState([])
+  const [achievementsUsers, setAchievementsUsers] = useAtom(achievementsUsersAtom)
+
+  const [newAchievement, setNewAchievement] = useState(defaultNewAchievement)
+
+  const [selectedUsers, setSelectedUsers] = useState([])
+  const [selectedAchievementId, setSelectedAchievementId] = useState('')
+  const [selectedEventId, setSelectedEventId] = useState('')
+  const [issueComment, setIssueComment] = useState('')
+  const [isIssuing, setIssuing] = useState(false)
+  const [isCreating, setCreating] = useState(false)
+  const [savingIds, setSavingIds] = useState([])
+  const [deletingIds, setDeletingIds] = useState([])
+  const [removingUserAchievementIds, setRemovingUserAchievementIds] = useState([])
+
+  useEffect(() => {
+    setEditedAchievements(
+      achievements.map((achievement) => ({ ...achievement }))
+    )
+  }, [achievements])
+
+  const updateEditedAchievement = (id, field, value) => {
+    setEditedAchievements((state) =>
+      state.map((item) =>
+        item._id === id
+          ? {
+              ...item,
+              [field]: value,
+            }
+          : item
+      )
+    )
+  }
+
+  const handleCreateAchievement = async () => {
+    if (!newAchievement.name.trim()) {
+      snackbar.error('Укажите название достижения')
+      return
+    }
+
+    setCreating(true)
+    const payload = {
+      name: newAchievement.name.trim(),
+      description: newAchievement.description?.trim() ?? '',
+      image: newAchievement.image ?? '',
+    }
+
+    try {
+      const created = await postData(
+        `/api/${location}/achievements`,
+        payload,
+        null,
+        null,
+        false,
+        loggedUser?._id
+      )
+
+      if (created) {
+        setAchievements((state) => [...state, created])
+        setNewAchievement(defaultNewAchievement)
+        snackbar.success('Достижение создано')
+      }
+    } catch (error) {
+      snackbar.error('Не удалось создать достижение')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleSaveAchievement = async (achievement) => {
+    const original = achievements.find(({ _id }) => _id === achievement._id)
+    if (!original || compareObjects(original, achievement)) return
+
+    setSavingIds((state) => [...state, achievement._id])
+    const payload = {
+      name: achievement.name?.trim() ?? '',
+      description: achievement.description?.trim() ?? '',
+      image: achievement.image ?? '',
+    }
+
+    try {
+      const updated = await putData(
+        `/api/${location}/achievements/${achievement._id}`,
+        payload,
+        null,
+        null,
+        false,
+        loggedUser?._id
+      )
+
+      if (updated) {
+        setAchievements((state) =>
+          state.map((item) => (item._id === updated._id ? updated : item))
+        )
+        snackbar.success('Достижение обновлено')
+      }
+    } catch (error) {
+      snackbar.error('Не удалось сохранить достижение')
+    } finally {
+      setSavingIds((state) => state.filter((id) => id !== achievement._id))
+    }
+  }
+
+  const handleDeleteAchievement = (achievementId) => {
+    modalsFunc.confirm({
+      title: 'Удаление достижения',
+      text: 'Вы уверены, что хотите удалить достижение? Это действие нельзя отменить.',
+      onConfirm: async () => {
+        setDeletingIds((state) => [...state, achievementId])
+        try {
+          const result = await deleteData(
+            `/api/${location}/achievements/${achievementId}`,
+            null,
+            null,
+            {},
+            false,
+            loggedUser?._id
+          )
+
+          if (result !== null) {
+            setAchievements((state) =>
+              state.filter((achievement) => achievement._id !== achievementId)
+            )
+            setEditedAchievements((state) =>
+              state.filter((achievement) => achievement._id !== achievementId)
+            )
+            snackbar.success('Достижение удалено')
+          }
+        } catch (error) {
+          snackbar.error('Не удалось удалить достижение')
+        } finally {
+          setDeletingIds((state) =>
+            state.filter((id) => id !== achievementId)
+          )
+        }
+      },
+    })
+  }
+
+  const openUsersModal = () => {
+    modalsFunc.selectUsers(
+      selectedUsers,
+      null,
+      (usersList) => setSelectedUsers(usersList ?? []),
+      null,
+      null,
+      null,
+      true,
+      'Выбор пользователей',
+      false
+    )
+  }
+
+  const removeSelectedUser = (userId) => {
+    setSelectedUsers((state) => state.filter((user) => user._id !== userId))
+  }
+
+  const handleIssueAchievement = async () => {
+    if (!selectedAchievementId) {
+      snackbar.error('Выберите достижение для выдачи')
+      return
+    }
+    if (selectedUsers.length === 0) {
+      snackbar.error('Выберите хотя бы одного пользователя')
+      return
+    }
+
+    setIssuing(true)
+    const event = events.find(({ _id }) => String(_id) === selectedEventId)
+    const createdRecords = []
+    const skippedUsers = []
+    const normalizedAchievementId = String(selectedAchievementId)
+    const alreadyIssuedUserIds = new Set(
+      (achievementsUsers ?? [])
+        .filter(
+          ({ achievementId }) =>
+            String(achievementId) === normalizedAchievementId
+        )
+        .map(({ userId }) => String(userId))
+    )
+
+    try {
+      for (const user of selectedUsers) {
+        const userId = String(user._id)
+        if (alreadyIssuedUserIds.has(userId)) {
+          skippedUsers.push(user)
+          continue
+        }
+
+        const payload = {
+          achievementId: selectedAchievementId,
+          userId: user._id,
+          eventId: selectedEventId || null,
+          eventName: event?.title ?? '',
+          comment: issueComment?.trim() ?? '',
+        }
+
+        const created = await postData(
+          `/api/${location}/achievementsusers`,
+          payload,
+          null,
+          null,
+          false,
+          loggedUser?._id
+        )
+
+        if (created) {
+          createdRecords.push(created)
+          alreadyIssuedUserIds.add(userId)
+        }
+      }
+
+      if (createdRecords.length > 0) {
+        setAchievementsUsers((state) => [...state, ...createdRecords])
+        snackbar.success(
+          `Достижение выдано ${createdRecords.length} пользовател${
+            createdRecords.length === 1 ? 'ю' : 'ям'
+          }`
+        )
+        setSelectedUsers([])
+        setIssueComment('')
+      }
+
+      if (skippedUsers.length > 0) {
+        snackbar.info(
+          `Пропущено ${skippedUsers.length} пользовател${
+            skippedUsers.length === 1 ? 'я' : 'ей'
+          }, у которых уже есть это достижение`
+        )
+      }
+    } catch (error) {
+      snackbar.error('Не удалось выдать достижение')
+    } finally {
+      setIssuing(false)
+    }
+  }
+
+  const achievementsUsersDetailed = useMemo(() => {
+    return achievementsUsers
+      ?.map((item) => {
+        const achievement = achievements.find(
+          ({ _id }) => String(_id) === String(item.achievementId)
+        )
+        const user = users?.find(
+          ({ _id }) => String(_id) === String(item.userId)
+        )
+        const event = events.find(
+          ({ _id }) => String(_id) === String(item.eventId)
+        )
+
+        return {
+          ...item,
+          achievement,
+          user,
+          event,
+        }
+      })
+      .sort((a, b) => new Date(b.issuedAt) - new Date(a.issuedAt))
+  }, [achievementsUsers, achievements, users, events])
+
+  const handleRemoveUserAchievement = async (id) => {
+    setRemovingUserAchievementIds((state) => [...state, id])
+    try {
+      const result = await deleteData(
+        `/api/${location}/achievementsusers/${id}`,
+        null,
+        null,
+        {},
+        false,
+        loggedUser?._id
+      )
+
+      if (result !== null) {
+        setAchievementsUsers((state) =>
+          state.filter((assignment) => assignment._id !== id)
+        )
+        snackbar.success('Назначение достижения удалено')
+      }
+    } catch (error) {
+      snackbar.error('Не удалось удалить назначение достижения')
+    } finally {
+      setRemovingUserAchievementIds((state) =>
+        state.filter((assignmentId) => assignmentId !== id)
+      )
+    }
+  }
+
+  const isCreateDisabled = !newAchievement.name.trim() || isCreating
+  const isIssueDisabled =
+    !selectedAchievementId || selectedUsers.length === 0 || isIssuing
+
+  return (
+    <div className="flex flex-col flex-1 h-screen max-h-screen gap-y-4 overflow-y-auto p-2">
+      <FormWrapper className="flex flex-col gap-y-3">
+        <h2 className="text-lg font-semibold">Создание нового достижения</h2>
+        <div className="grid gap-3 tablet:grid-cols-2">
+          <Input
+            label="Название"
+            value={newAchievement.name}
+            onChange={(value) =>
+              setNewAchievement((state) => ({ ...state, name: value }))
+            }
+          />
+          <InputImage
+            label="Изображение"
+            directory="achievements"
+            image={newAchievement.image}
+            onChange={(value) =>
+              setNewAchievement((state) => ({ ...state, image: value }))
+            }
+          />
+        </div>
+        <Textarea
+          label="Описание"
+          value={newAchievement.description}
+          onChange={(value) =>
+            setNewAchievement((state) => ({ ...state, description: value }))
+          }
+          rows={3}
+        />
+        <div className="flex gap-2">
+          <Button
+            name="Создать"
+            onClick={handleCreateAchievement}
+            disabled={isCreateDisabled}
+            loading={isCreating}
+          />
+        </div>
+      </FormWrapper>
+
+      {editedAchievements.length > 0 && (
+        <FormWrapper className="flex flex-col gap-y-3">
+          <h2 className="text-lg font-semibold">Существующие достижения</h2>
+          <div className="grid gap-3 laptop:grid-cols-2">
+            {editedAchievements.map((achievement) => {
+              const original = achievements.find(
+                ({ _id }) => _id === achievement._id
+              )
+              const isChanged =
+                original && !compareObjects(original, achievement)
+
+              return (
+                <div
+                  key={achievement._id}
+                  className="flex flex-col gap-y-2 rounded-lg border border-gray-200 bg-white p-3 shadow-sm"
+                >
+                  <Input
+                    label="Название"
+                    value={achievement.name}
+                    onChange={(value) =>
+                      updateEditedAchievement(achievement._id, 'name', value)
+                    }
+                  />
+                  <Textarea
+                    label="Описание"
+                    value={achievement.description ?? ''}
+                    onChange={(value) =>
+                      updateEditedAchievement(
+                        achievement._id,
+                        'description',
+                        value
+                      )
+                    }
+                    rows={3}
+                  />
+                  <div>
+                    <div className="text-xs font-medium text-gray-600">
+                      Изображение
+                    </div>
+                    <div className="mt-1">
+                      <InputImage
+                        directory="achievements"
+                        image={achievement.image}
+                        onChange={(value) =>
+                          updateEditedAchievement(
+                            achievement._id,
+                            'image',
+                            value
+                          )
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2 pt-1">
+                    <Button
+                      name="Сохранить"
+                      onClick={() => handleSaveAchievement(achievement)}
+                      disabled={!isChanged || savingIds.includes(achievement._id)}
+                      loading={savingIds.includes(achievement._id)}
+                    />
+                    <Button
+                      name="Удалить"
+                      classBgColor="bg-red-600"
+                      classHoverBgColor="hover:bg-red-700"
+                      onClick={() => handleDeleteAchievement(achievement._id)}
+                      disabled={deletingIds.includes(achievement._id)}
+                      loading={deletingIds.includes(achievement._id)}
+                    />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </FormWrapper>
+      )}
+
+      <FormWrapper className="flex flex-col gap-y-3">
+        <h2 className="text-lg font-semibold">Выдача достижений пользователям</h2>
+        <div className="grid gap-3 laptop:grid-cols-2">
+          <div className="flex flex-col gap-y-2">
+            <div className="text-xs font-medium uppercase tracking-wide text-gray-500">
+              Выбранные пользователи
+            </div>
+            <div className="flex flex-wrap gap-2 rounded-lg border border-gray-200 bg-white p-2 min-h-[3.25rem]">
+              {selectedUsers.length === 0 && (
+                <div className="text-sm text-gray-500">Пользователи не выбраны</div>
+              )}
+              {selectedUsers.map((user) => (
+                <div
+                  key={user._id}
+                  className="flex items-center gap-x-2 rounded-full bg-gray-100 px-3 py-1 text-sm"
+                >
+                  <span>{getUserFullName(user)}</span>
+                  <button
+                    type="button"
+                    className="text-gray-500 transition hover:text-red-600"
+                    onClick={() => removeSelectedUser(user._id)}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+            <Button name="Выбрать пользователей" onClick={openUsersModal} />
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <label className="text-xs font-medium uppercase tracking-wide text-gray-500">
+              Достижение
+            </label>
+            <select
+              className="h-10 rounded border border-gray-300 bg-white px-3 text-sm focus:border-general focus:outline-none"
+              value={selectedAchievementId}
+              onChange={(event) => setSelectedAchievementId(event.target.value)}
+            >
+              <option value="">Не выбрано</option>
+              {achievements.map((achievement) => (
+                <option key={achievement._id} value={achievement._id}>
+                  {achievement.name}
+                </option>
+              ))}
+            </select>
+            <label className="pt-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+              Мероприятие (необязательно)
+            </label>
+            <select
+              className="h-10 rounded border border-gray-300 bg-white px-3 text-sm focus:border-general focus:outline-none"
+              value={selectedEventId}
+              onChange={(event) => setSelectedEventId(event.target.value)}
+            >
+              <option value="">Не выбрано</option>
+              {events
+                .slice()
+                .sort((a, b) => {
+                  const toTime = (item) => {
+                    const value = item?.dateStart || item?.date
+                    const time = value ? new Date(value).getTime() : 0
+                    return Number.isNaN(time) ? 0 : time
+                  }
+                  return toTime(b) - toTime(a)
+                })
+                .map((event) => (
+                  <option key={event._id} value={event._id}>
+                    {event.title}
+                  </option>
+                ))}
+            </select>
+          </div>
+        </div>
+        <Textarea
+          label="Комментарий (необязательно)"
+          value={issueComment}
+          onChange={setIssueComment}
+          rows={3}
+        />
+        <div className="flex gap-2">
+          <Button
+            name="Выдать достижение"
+            onClick={handleIssueAchievement}
+            disabled={isIssueDisabled}
+            loading={isIssuing}
+          />
+        </div>
+      </FormWrapper>
+
+      <FormWrapper className="flex flex-col gap-y-3">
+        <h2 className="text-lg font-semibold">Выданные достижения</h2>
+        {achievementsUsersDetailed?.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                <tr>
+                  <th className="px-3 py-2 text-left">Пользователь</th>
+                  <th className="px-3 py-2 text-left">Достижение</th>
+                  <th className="px-3 py-2 text-left">Мероприятие</th>
+                  <th className="px-3 py-2 text-left">Комментарий</th>
+                  <th className="px-3 py-2 text-left">Дата</th>
+                  <th className="px-3 py-2" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 bg-white">
+                {achievementsUsersDetailed.map((item) => {
+                  const userName = item.user
+                    ? getUserFullName(item.user)
+                    : 'Пользователь удалён'
+                  const achievementName = item.achievement
+                    ? item.achievement.name
+                    : 'Достижение удалено'
+                  const eventName = item.event?.title || item.eventName || ''
+
+                  return (
+                    <tr key={item._id} className="align-top">
+                      <td className="px-3 py-2 text-gray-900">{userName}</td>
+                      <td className="px-3 py-2 text-gray-900">
+                        <div className="flex items-center gap-x-2">
+                          {item.achievement?.image && (
+                            <div className="relative h-10 w-10 overflow-hidden rounded">
+                              <Image
+                                src={item.achievement.image}
+                                alt={achievementName}
+                                layout="fill"
+                                objectFit="cover"
+                                sizes="40px"
+                              />
+                            </div>
+                          )}
+                          <span>{achievementName}</span>
+                        </div>
+                      </td>
+                      <td className="px-3 py-2 text-gray-700">
+                        {eventName || <span className="text-gray-400">—</span>}
+                      </td>
+                      <td className="px-3 py-2 text-gray-700 whitespace-pre-line">
+                        {item.comment || <span className="text-gray-400">—</span>}
+                      </td>
+                      <td className="px-3 py-2 text-gray-600 whitespace-nowrap">
+                        {formatDateTime(
+                          item.issuedAt,
+                          true,
+                          false,
+                          false,
+                          false,
+                          undefined,
+                          true,
+                          true
+                        )}
+                      </td>
+                      <td className="px-3 py-2">
+                        <Button
+                          name="Удалить"
+                          classBgColor="bg-red-600"
+                          classHoverBgColor="hover:bg-red-700"
+                          thin
+                          onClick={() => handleRemoveUserAchievement(item._id)}
+                          disabled={removingUserAchievementIds.includes(item._id)}
+                          loading={removingUserAchievementIds.includes(item._id)}
+                        />
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="text-sm text-gray-500">
+            Достижения ещё не были выданы пользователям.
+          </div>
+        )}
+      </FormWrapper>
+    </div>
+  )
+}
+
+export default SettingsAchievementsContent

--- a/layouts/content/SettingsRolesContent.js
+++ b/layouts/content/SettingsRolesContent.js
@@ -431,6 +431,11 @@ const SettingsRolesContent = (props) => {
               subItem="referralSystem"
             />
             <RoleItem
+              label="Настройки достижений"
+              item="siteSettings"
+              subItem="achievements"
+            />
+            <RoleItem
               label="Редактирование ролей"
               item="siteSettings"
               subItem="roles"

--- a/pages/api/[location]/achievements/[id].js
+++ b/pages/api/[location]/achievements/[id].js
@@ -1,0 +1,5 @@
+import CRUD from '@server/CRUD'
+
+export default async function handler(req, res) {
+  return await CRUD('Achievements', req, res)
+}

--- a/pages/api/[location]/achievements/index.js
+++ b/pages/api/[location]/achievements/index.js
@@ -1,0 +1,5 @@
+import CRUD from '@server/CRUD'
+
+export default async function handler(req, res) {
+  return await CRUD('Achievements', req, res)
+}

--- a/pages/api/[location]/achievementsusers/[id].js
+++ b/pages/api/[location]/achievementsusers/[id].js
@@ -1,0 +1,5 @@
+import CRUD from '@server/CRUD'
+
+export default async function handler(req, res) {
+  return await CRUD('AchievementsUsers', req, res)
+}

--- a/pages/api/[location]/achievementsusers/index.js
+++ b/pages/api/[location]/achievementsusers/index.js
@@ -1,0 +1,5 @@
+import CRUD from '@server/CRUD'
+
+export default async function handler(req, res) {
+  return await CRUD('AchievementsUsers', req, res)
+}

--- a/schemas/achievementsSchema.js
+++ b/schemas/achievementsSchema.js
@@ -1,0 +1,17 @@
+const achievementsSchema = {
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+  image: {
+    type: String,
+    default: '',
+  },
+}
+
+export default achievementsSchema

--- a/schemas/achievementsUsersSchema.js
+++ b/schemas/achievementsUsersSchema.js
@@ -1,0 +1,33 @@
+import { Schema } from 'mongoose'
+
+const achievementsUsersSchema = {
+  userId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Users',
+    required: true,
+  },
+  achievementId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Achievements',
+    required: true,
+  },
+  eventId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Events',
+    default: null,
+  },
+  eventName: {
+    type: String,
+    default: '',
+  },
+  comment: {
+    type: String,
+    default: '',
+  },
+  issuedAt: {
+    type: Date,
+    default: () => Date.now(),
+  },
+}
+
+export default achievementsUsersSchema

--- a/schemas/rolesSchema.js
+++ b/schemas/rolesSchema.js
@@ -161,6 +161,7 @@ const rolesSchema = {
       phoneConfirmService: false,
       fabMenu: false,
       referralSystem: false,
+      achievements: false,
       roles: false,
     },
   },

--- a/server/fetchProps.js
+++ b/server/fetchProps.js
@@ -26,6 +26,8 @@ const fetchProps = async (user, location, params) => {
         questionnaires: [],
         questionnairesUsers: [],
         services: [],
+        achievements: [],
+        achievementsUsers: [],
         // servicesUsers: [],
         serverSettings: JSON.parse(
           JSON.stringify({
@@ -156,6 +158,16 @@ const fetchProps = async (user, location, params) => {
         : await db.model('Services').find({}).lean()
     // const servicesUsers = await db.model('ServicesUsers').find({}).lean()
 
+    const achievements =
+      params?.achievements === false
+        ? []
+        : await db.model('Achievements').find({}).lean()
+
+    const achievementsUsers =
+      params?.achievementsUsers === false
+        ? []
+        : await db.model('AchievementsUsers').find({}).lean()
+
     // const userRole = getUserRole(user, [...DEFAULT_ROLES, ...rolesSettings])
     // const seeFullNames = userRole?.users?.seeFullNames
 
@@ -249,6 +261,8 @@ const fetchProps = async (user, location, params) => {
       questionnaires: JSON.parse(JSON.stringify(questionnaires)),
       questionnairesUsers: JSON.parse(JSON.stringify(questionnairesUsers)),
       services: JSON.parse(JSON.stringify(services)),
+      achievements: JSON.parse(JSON.stringify(achievements)),
+      achievementsUsers: JSON.parse(JSON.stringify(achievementsUsers)),
       // servicesUsers: JSON.parse(JSON.stringify(servicesUsers)),
       serverSettings: JSON.parse(
         JSON.stringify({
@@ -276,6 +290,8 @@ const fetchProps = async (user, location, params) => {
       questionnaires: [],
       questionnairesUsers: [],
       services: [],
+      achievements: [],
+      achievementsUsers: [],
       // servicesUsers: [],
       serverSettings: JSON.parse(
         JSON.stringify({

--- a/state/atoms/achievementsAtom.js
+++ b/state/atoms/achievementsAtom.js
@@ -1,0 +1,5 @@
+import { atom } from 'jotai'
+
+const achievementsAtom = atom([])
+
+export default achievementsAtom

--- a/state/atoms/achievementsUsersAtom.js
+++ b/state/atoms/achievementsUsersAtom.js
@@ -1,0 +1,5 @@
+import { atom } from 'jotai'
+
+const achievementsUsersAtom = atom([])
+
+export default achievementsUsersAtom

--- a/state/selectors/menuHiddenLoggedUserAchievementsSelector.js
+++ b/state/selectors/menuHiddenLoggedUserAchievementsSelector.js
@@ -1,0 +1,19 @@
+'use client'
+
+import { atom } from 'jotai'
+
+import achievementsUsersAtom from '@state/atoms/achievementsUsersAtom'
+import loggedUserActiveAtom from '@state/atoms/loggedUserActiveAtom'
+
+const menuHiddenLoggedUserAchievementsSelector = atom((get) => {
+  const loggedUser = get(loggedUserActiveAtom)
+  const achievementsUsers = get(achievementsUsersAtom)
+
+  if (!loggedUser?._id) return true
+
+  return !achievementsUsers?.some(
+    (achievement) => String(achievement.userId) === String(loggedUser._id)
+  )
+})
+
+export default menuHiddenLoggedUserAchievementsSelector

--- a/utils/dbConnect.js
+++ b/utils/dbConnect.js
@@ -1,6 +1,8 @@
 import mongoose from 'mongoose'
 
 import additionalBlocksSchema from '@schemas/additionalBlocksSchema'
+import achievementsSchema from '@schemas/achievementsSchema'
+import achievementsUsersSchema from '@schemas/achievementsUsersSchema'
 import directionsSchema from '@schemas/directionsSchema'
 import eventsSchema from '@schemas/eventsSchema'
 import eventsUsersSchema from '@schemas/eventsUsersSchema'
@@ -192,6 +194,14 @@ async function dbConnect(location) {
     connections[location].model(
       'Users',
       mongoose.Schema(usersSchema, { timestamps: true })
+    )
+    connections[location].model(
+      'Achievements',
+      mongoose.Schema(achievementsSchema, { timestamps: true })
+    )
+    connections[location].model(
+      'AchievementsUsers',
+      mongoose.Schema(achievementsUsersSchema, { timestamps: true })
     )
     connections[location].model(
       'Events',


### PR DESCRIPTION
## Summary
- add backend models and API routes for achievements and issued achievements tied to events
- provide settings UI to create, edit, and assign achievements and a new "My Achievements" view for users
- extend roles, navigation, and state loading to expose achievements while hiding the menu when no awards exist

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2bc7f57dc83299fc69e301f137c23